### PR TITLE
Fix/tagging typeahead

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,20 @@
   "private": true,
   "devDependencies": {
     "pocket-build-tools": "git+https://git@github.com/Pocket/front-end-build-tools.git",
+    "redux-devtools-extension": "^2.13.2",
     "remote-redux-devtools": "^0.5.12"
   },
   "dependencies": {
     "autosize-input": "^0.4.0",
     "blueimp-md5": "^2.10.0",
     "classnames": "^2.2.5",
+    "downshift": "^1.25.0",
+    "match-sorter": "^2.2.0",
     "prop-types": "^15.5.10",
     "react": "^16.0.0",
     "react-chrome-redux": "1.4.0",
     "react-dom": "^16.0.0",
+    "react-input-autosize": "^2.2.1",
     "react-motion": "^0.5.2",
     "react-onclickoutside": "^6.6.0",
     "react-redux": "^5.0.5",

--- a/src/containers/background/_setup.js
+++ b/src/containers/background/_setup.js
@@ -116,7 +116,7 @@ function* hydrateState() {
         account_name_first: getSetting('account_name_first'),
         account_name_last: getSetting('account_name_last'),
         account_avatar: getSetting('account_avatar'),
-        account_premium: getBool(getSetting('base_key_shortcut_active')),
+        account_premium: getBool(getSetting('account_premium')),
         key_shortcuts: keyShortcutArray,
         on_save_recommendations: getBool(getSetting('on_save_recommendations')),
         sites_facebook: getBool(getSetting('sites_facebook')),

--- a/src/containers/background/_setup.js
+++ b/src/containers/background/_setup.js
@@ -67,6 +67,13 @@ export const setup = (state = initialState, action) => {
             }
         }
 
+        case 'UPDATE_STORED_TAGS': {
+            return {
+                ...state,
+                tags_stored: [...action.tags]
+            }
+        }
+
         default: {
             return state
         }
@@ -115,7 +122,8 @@ function* hydrateState() {
         sites_facebook: getBool(getSetting('sites_facebook')),
         sites_hackernews: getBool(getSetting('sites_hackernews')),
         sites_reddit: getBool(getSetting('sites_reddit')),
-        sites_twitter: getBool(getSetting('sites_twitter'))
+        sites_twitter: getBool(getSetting('sites_twitter')),
+        tags_stored: JSON.parse(getSetting('tags_stored')) || []
     }
 
     yield put({ type: 'HYDRATED_STATE', hydrated })

--- a/src/containers/save/save.app.js
+++ b/src/containers/save/save.app.js
@@ -100,6 +100,7 @@ class App extends Component {
                         closePanel={this.closePanel}
                         removeTag={this.props.removeTag}
                         removeTags={this.props.removeTags}
+                        storedTags={this.props.setup.tags_stored}
                     />
                 )}
                 {this.showRecs && (

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -1,30 +1,47 @@
 import { delay } from 'redux-saga'
 import { put, call, takeLatest, select } from 'redux-saga/effects'
 import * as API from '../../../../common/api/'
+import { setSettings } from '../../../../common/interface'
 
 // ACTIONS
 export const taggingActions = {
-    getTags:        ()      => { return { type: 'TAG_REQUEST' }},
-    activateTag:    data    => { return { type: 'TAG_ACTIVATE', data }},
-    deactivateTag:  data    => { return { type: 'TAG_DEACTIVATE', data }},
-    addTag:         tag     => { return { type: 'TAG_ADD', tag }},
-    deactivateTags: data    => { return { type: 'TAGS_DEACTIVATE', data }},
-    removeTag:      data    => { return { type: 'TAG_REMOVE', data }},
-    removeTags:     data    => { return { type: 'TAGS_REMOVE', data }}
+    getTags: () => {
+        return { type: 'TAG_REQUEST' }
+    },
+    activateTag: data => {
+        return { type: 'TAG_ACTIVATE', data }
+    },
+    deactivateTag: data => {
+        return { type: 'TAG_DEACTIVATE', data }
+    },
+    addTag: tag => {
+        return { type: 'TAG_ADD', tag }
+    },
+    deactivateTags: data => {
+        return { type: 'TAGS_DEACTIVATE', data }
+    },
+    removeTag: data => {
+        return { type: 'TAG_REMOVE', data }
+    },
+    removeTags: data => {
+        return { type: 'TAGS_REMOVE', data }
+    }
 }
 
-function checkDuplicate(list, tagValue){
-    return list.used.filter( tag => tag.name === tagValue).length
+function checkDuplicate(list, tagValue) {
+    return list.used.filter(tag => tag.name === tagValue).length
 }
 
 // REDUCERS
 export const tags = (state = {}, action) => {
     switch (action.type) {
         case 'SAVE_TO_POCKET_SUCCESS': {
+            const usedTags = state[action.saveHash]
+                ? [...state[action.saveHash].used]
+                : []
 
-            const usedTags = state[action.saveHash] ? [...state[action.saveHash].used] : []
-
-            return {...state,
+            return {
+                ...state,
                 [action.saveHash]: {
                     ...state[action.saveHash],
                     used: usedTags,
@@ -33,12 +50,13 @@ export const tags = (state = {}, action) => {
             }
         }
 
-        case 'SUGGESTED_TAGS_SUCCESS':{
+        case 'SUGGESTED_TAGS_SUCCESS': {
             const suggestedTags = action.tags
-            const saveHash      = action.saveHash
-            const tags          = state[saveHash]
-            return {...state,
-                [saveHash]:{
+            const saveHash = action.saveHash
+            const tags = state[saveHash]
+            return {
+                ...state,
+                [saveHash]: {
                     ...tags,
                     suggested: suggestedTags
                 }
@@ -46,31 +64,30 @@ export const tags = (state = {}, action) => {
         }
 
         case 'TAG_ADD': {
-
-            const saveHash  = action.tag.saveHash
-            const tagValue  = action.tag.value
-            const tags      = state[saveHash]
+            const saveHash = action.tag.saveHash
+            const tagValue = action.tag.value
+            const tags = state[saveHash]
 
             // Don't add duplicate entries
-            if(checkDuplicate(tags, tagValue)) return state
+            if (checkDuplicate(tags, tagValue)) return state
 
-            return {...state,
-                [saveHash]:{
+            return {
+                ...state,
+                [saveHash]: {
                     ...tags,
                     used: [...tags.used, tagValue]
                 }
             }
-
         }
 
         case 'TAG_REMOVE': {
-            const saveHash  = action.data.saveHash
-            const tag       = action.data.tag
-            const usedTags  = state[saveHash].used
-                .filter( item => item !== tag)
+            const saveHash = action.data.saveHash
+            const tag = action.data.tag
+            const usedTags = state[saveHash].used.filter(item => item !== tag)
 
-            return {...state,
-                [saveHash]:{
+            return {
+                ...state,
+                [saveHash]: {
                     ...state[saveHash],
                     used: usedTags
                 }
@@ -78,20 +95,19 @@ export const tags = (state = {}, action) => {
         }
 
         case 'TAG_ACTIVATE': {
-            const saveHash      = action.data.saveHash
-            const currentTags   = state[saveHash].used
-            const tagIndex      = currentTags.indexOf(action.data.tag)
-            const markedTags    = state[saveHash].marked
+            const saveHash = action.data.saveHash
+            const currentTags = state[saveHash].used
+            const tagIndex = currentTags.indexOf(action.data.tag)
+            const markedTags = state[saveHash].marked
 
-            const tagPosition   = (tagIndex < 0) ?
-                currentTags.length-1 :
-                tagIndex
+            const tagPosition = tagIndex < 0 ? currentTags.length - 1 : tagIndex
 
-            const markedTag     = currentTags.slice(tagPosition, tagPosition+1)[0]
-            if(markedTags.includes(markedTag)) return state
+            const markedTag = currentTags.slice(tagPosition, tagPosition + 1)[0]
+            if (markedTags.includes(markedTag)) return state
 
-            return {...state,
-                [saveHash]:{
+            return {
+                ...state,
+                [saveHash]: {
                     ...state[saveHash],
                     marked: [...markedTags, markedTag]
                 }
@@ -99,13 +115,15 @@ export const tags = (state = {}, action) => {
         }
 
         case 'TAG_DEACTIVATE': {
-            const saveHash      = action.data.saveHash
-            const tag           = action.data.tag
-            const markedTags    = state[saveHash].marked
-                .filter( item => item !== tag)
+            const saveHash = action.data.saveHash
+            const tag = action.data.tag
+            const markedTags = state[saveHash].marked.filter(
+                item => item !== tag
+            )
 
-            return {...state,
-                [saveHash]:{
+            return {
+                ...state,
+                [saveHash]: {
                     ...state[saveHash],
                     marked: markedTags
                 }
@@ -113,9 +131,10 @@ export const tags = (state = {}, action) => {
         }
 
         case 'TAGS_DEACTIVATE': {
-            const saveHash      = action.data.saveHash
-            return {...state,
-                [saveHash]:{
+            const saveHash = action.data.saveHash
+            return {
+                ...state,
+                [saveHash]: {
                     ...state[saveHash],
                     marked: []
                 }
@@ -123,18 +142,19 @@ export const tags = (state = {}, action) => {
         }
 
         case 'TAGS_REMOVE': {
-            const saveHash      = action.data.saveHash
-            const currentTags   = state[saveHash].used
-            const markedTags    = state[saveHash].marked
+            const saveHash = action.data.saveHash
+            const currentTags = state[saveHash].used
+            const markedTags = state[saveHash].marked
 
-            if(!markedTags.length) return state
+            if (!markedTags.length) return state
 
-            const filteredTags = currentTags.filter( tag => {
+            const filteredTags = currentTags.filter(tag => {
                 return !markedTags.includes(tag)
             })
 
-            return {...state,
-                [saveHash]:{
+            return {
+                ...state,
+                [saveHash]: {
                     ...state[saveHash],
                     used: filteredTags,
                     marked: []
@@ -142,18 +162,24 @@ export const tags = (state = {}, action) => {
             }
         }
 
-        default: {return state}
+        default: {
+            return state
+        }
     }
 }
 
 // SAGAS
-export function* wSuggestedTags() { yield takeLatest('SUGGESTED_TAGS_REQUEST', tagSuggestions)}
-export function* wTagChanges() { yield takeLatest(['TAG_ADD','TAG_REMOVE', 'TAGS_REMOVE'], tagChanges)}
+export function* wSuggestedTags() {
+    yield takeLatest('SUGGESTED_TAGS_REQUEST', tagSuggestions)
+}
+export function* wTagChanges() {
+    yield takeLatest(['TAG_ADD', 'TAG_REMOVE', 'TAGS_REMOVE'], tagChanges)
+}
 
-const getUsedTags   = ( state ) => {
-    const activeTabId   = state.active
-    const activeTab     = state.tabs[activeTabId]
-    const activeHash    = activeTab.hash
+const getUsedTags = state => {
+    const activeTabId = state.active
+    const activeTab = state.tabs[activeTabId]
+    const activeHash = activeTab.hash
 
     return {
         url: state.saves[activeHash].url,
@@ -161,21 +187,37 @@ const getUsedTags   = ( state ) => {
     }
 }
 
-function* tagSuggestions( action ){
+const getStoredTags = state => {
+    return state.setup.tags_stored
+}
+
+function* tagSuggestions(action) {
     try {
-        const tagData   = yield call( API.getOnSaveTags, action.saveObject, action.resolved_id )
-        const tags      = tagData[0].response.suggested_tags.map( item => item.tag )
-        const saveHash  = tagData[0].saveObject.saveHash
+        const tagData = yield call(
+            API.getOnSaveTags,
+            action.saveObject,
+            action.resolved_id
+        )
+        const tags = tagData[0].response.suggested_tags.map(item => item.tag)
+        const saveHash = tagData[0].saveObject.saveHash
 
         yield put({ type: 'SUGGESTED_TAGS_SUCCESS', tags, saveHash })
-    } catch ( error ) {
+    } catch (error) {
         yield put({ type: 'SUGGESTED_TAGS_FAILURE', error })
     }
 }
 
-
-function* tagChanges(){
+function* tagChanges() {
     yield delay(2000)
-    const tagInfo = yield select( getUsedTags )
-    yield call( API.syncItemTags, tagInfo.url, tagInfo.tags )
+    const tagInfo = yield select(getUsedTags)
+
+    const tags = [...tagInfo.tags]
+    const storedTags = yield select(getStoredTags)
+    const tagsToStore = [...tags, ...storedTags].filter(
+        (elem, pos, arr) => arr.indexOf(elem) === pos
+    )
+    setSettings({ tags_stored: JSON.stringify(tagsToStore) })
+    yield put({ type: 'UPDATE_STORED_TAGS', tags: tagsToStore })
+
+    yield call(API.syncItemTags, tagInfo.url, tagInfo.tags)
 }

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -179,6 +179,9 @@ export function* wTagChanges() {
 const getUsedTags = state => {
     const activeTabId = state.active
     const activeTab = state.tabs[activeTabId]
+
+    if (!activeTab) return false
+
     const activeHash = activeTab.hash
 
     return {
@@ -188,7 +191,7 @@ const getUsedTags = state => {
 }
 
 const getStoredTags = state => {
-    return state.setup.tags_stored
+    return state.setup.tags_stored || []
 }
 
 function* tagSuggestions(action) {
@@ -210,6 +213,8 @@ function* tagSuggestions(action) {
 function* tagChanges() {
     yield delay(2000)
     const tagInfo = yield select(getUsedTags)
+
+    if (!tagInfo) return yield put({ type: 'TAG_SYNC_FAILED' })
 
     const tags = [...tagInfo.tags]
     const storedTags = yield select(getStoredTags)

--- a/src/containers/save/toolbar/tagging/suggestions/suggestions.js
+++ b/src/containers/save/toolbar/tagging/suggestions/suggestions.js
@@ -1,47 +1,22 @@
 import styles from './suggestions.scss'
-import React, {Component} from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import classNames from 'classnames/bind'
-
-const cx = classNames.bind(styles)
 
 export default class Suggestions extends Component {
-
     prevent = event => {
         event.preventDefault()
     }
 
-    get listItems(){
+    get listItems() {
         return this.props.suggestions
-            .filter( item => !this.props.tags.includes(item) )
-            .map( (suggestion, index) => {
+            .filter(item => !this.props.tags.includes(item))
+            .map((suggestion, index) => {
                 return (
-                    <li key={index}
-                        onMouseDown = {event => this.prevent(event) }
-                        onClick={ () => this.props.addTag(suggestion) }
+                    <li
+                        key={index}
+                        onMouseDown={event => this.prevent(event)}
+                        onClick={() => this.props.addTag(suggestion)}
                         className={styles.suggestion}>
-                        {suggestion}
-                    </li>
-                )
-            })
-
-    }
-
-    get typeahead(){
-        return this.props.typeAhead()
-            .map( (item, index) => {
-
-                const suggestion = item.suggestion
-                const typeAheadClass = cx({
-                    typeahead: true,
-                    active: item.active
-                })
-
-                return (
-                    <li key={'ta'+index}
-                        onMouseDown = {event => this.prevent(event) }
-                        onClick={ () => this.props.addTag(suggestion)}
-                        className={typeAheadClass}>
                         {suggestion}
                     </li>
                 )
@@ -49,27 +24,19 @@ export default class Suggestions extends Component {
     }
 
     render() {
-
         return (
             <div className={styles.suggestions}>
-
-                { this.props.value.length < 1 &&
-                    <div>
-                        {/*<div className={styles.header}>Suggested Tags</div>*/}
-                        <ul className={styles.suggestionsList}>{this.listItems}</ul>
-                    </div>
-                }
-                { this.props.value.length > 0 &&
-                    <ul className={styles.typeaheadList}>{this.typeahead}</ul>
-                }
+                <div>
+                    {/*<div className={styles.header}>Suggested Tags</div>*/}
+                    <ul className={styles.suggestionsList}>{this.listItems}</ul>
+                </div>
             </div>
         )
     }
 }
 
 Suggestions.propTypes = {
-    suggestions : PropTypes.array,
-    typeAhead: PropTypes.func,
+    suggestions: PropTypes.array,
     addTag: PropTypes.func,
     value: PropTypes.string,
     tags: PropTypes.array

--- a/src/containers/save/toolbar/tagging/suggestions/suggestions.scss
+++ b/src/containers/save/toolbar/tagging/suggestions/suggestions.scss
@@ -6,6 +6,7 @@
     display: block;
     font-size: 13px;
     line-height: 17px;
+    margin-top: 2px;
     text-align: left;
     width: 100%;
 }

--- a/src/containers/save/toolbar/tagging/suggestions/suggestions.scss
+++ b/src/containers/save/toolbar/tagging/suggestions/suggestions.scss
@@ -50,22 +50,3 @@
     }
 }
 
-.typeaheadList {
-    display: block;
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-}
-
-.typeahead {
-    border-radius: 3px;
-    cursor: pointer;
-    display: block;
-    padding: 2px 8px;
-
-    &:hover,
-    &.active {
-        background-color: $teal;
-        color: $white;
-    }
-}

--- a/src/containers/save/toolbar/tagging/tagging.js
+++ b/src/containers/save/toolbar/tagging/tagging.js
@@ -188,7 +188,6 @@ export default class Tagging extends Component {
                             value={this.state.inputvalue}
                             tags={this.props.tags.used}
                             suggestions={this.props.tags.suggested}
-                            typeAhead={this.typeAhead}
                             addTag={this.addTag}
                             activate={this.activateTag}
                             activateSuggestion={this.activateSuggestion}

--- a/src/containers/save/toolbar/tagging/tagging.js
+++ b/src/containers/save/toolbar/tagging/tagging.js
@@ -1,10 +1,11 @@
 import styles from './tagging.scss'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import matchSorter from 'match-sorter'
 import Chips from './chips/chips'
+import Downshift from 'downshift'
 import Suggestions from './suggestions/suggestions'
 import Taginput from './taginput/taginput'
-import autosizeInput from 'autosize-input'
 import { localize } from '../../../../common/_locales/locales'
 import classNames from 'classnames/bind'
 
@@ -17,12 +18,9 @@ export default class Tagging extends Component {
             placeholder: !this.hasTags(),
             focused: false,
             inputvalue: '',
-            activeSuggestion: -1
+            activeSuggestion: -1,
+            typeaheadOpen: false
         }
-    }
-
-    componentDidMount() {
-        autosizeInput(this.input)
     }
 
     /* Utilities
@@ -41,11 +39,6 @@ export default class Tagging extends Component {
         this.setState({ placeholder: !status, focused: false })
     }
 
-    resetInput = () => {
-        this.input.focus()
-        this.input.style.width = '0.3em'
-    }
-
     /* Tag Management
     –––––––––––––––––––––––––––––––––––––––––––––––––– */
     addTag = value => {
@@ -53,7 +46,7 @@ export default class Tagging extends Component {
         if (this.props.tags.used.indexOf(value) >= 0) return
         this.props.addTag({ value, saveHash: this.props.saveHash })
         this.setState({ placeholder: false, inputvalue: '' })
-        this.resetInput()
+        this.input.focus()
     }
 
     /* Active/Inactive Tagging
@@ -87,57 +80,29 @@ export default class Tagging extends Component {
         this.input.focus()
     }
 
-    // onMouseDown = e => {
-    //     // MouseDown when input is active causes an
-    //     // Unnecessary reset of the placeholder
-    //     // Stopping propagation here is not an option
-    //     // due to the possibility of not having iFrame focus
-    // }
-
     onMouseUp = e => {
-        e.preventDefault()
         this.input.focus()
+        e.stopPropagation()
+        e.preventDefault()
     }
 
-    // Suggestions
-    get typeAheadSuggestions() {
-        const inputValue = this.state.inputvalue
-        if (!this.props.tags.suggested) return []
-        return this.props.tags.suggested
-            .filter(item => {
-                return inputValue.length ? item.indexOf(inputValue) > -1 : true
-            })
-            .slice(0, 3)
+    onStateChange = changes => {
+        if (typeof changes.isOpen !== 'undefined')
+            this.setState({ typeaheadOpen: changes.isOpen })
     }
 
-    typeAhead = () => {
-        return this.typeAheadSuggestions.map((item, index) => {
-            return {
-                suggestion: item,
-                active: index === this.state.activeSuggestion
-            }
-        })
-    }
+    onSelect = this.addTag
 
-    handleDirection = keycode => {
-        const typeAheadLength = this.typeAheadSuggestions.length
-        const activeSuggestion = this.state.activeSuggestion
-
-        if (activeSuggestion < 0) return this.setState({ activeSuggestion: 0 })
-
-        // DOWN
-        if (keycode === 40) {
-            return activeSuggestion === typeAheadLength - 1
-                ? this.setState({ activeSuggestion: 0 })
-                : this.setState({ activeSuggestion: activeSuggestion + 1 })
-        }
-
-        // UP
-        if (keycode === 38) {
-            return activeSuggestion === 0
-                ? this.setState({ activeSuggestion: typeAheadLength - 1 })
-                : this.setState({ activeSuggestion: activeSuggestion - 1 })
-        }
+    get storedTags() {
+        const value = this.state.inputvalue
+        const usedTags = this.hasTags() ? this.props.tags.used : []
+        const storedTags = this.props.storedTags || []
+        const filteredStoredTags = storedTags.filter(
+            item => usedTags.indexOf(item) < 0
+        )
+        return value
+            ? matchSorter(filteredStoredTags, value)
+            : filteredStoredTags
     }
 
     /* Render Component
@@ -150,37 +115,80 @@ export default class Tagging extends Component {
 
         return (
             <div className={styles.tagging}>
-                <div className={taggingClass} onMouseUp={this.onMouseUp}>
-                    {this.state.placeholder &&
-                        !this.hasTags() && (
-                            <div className={styles.placeholder}>
-                                {localize('tagging', 'add_tags')}
-                            </div>
-                        )}
-                    {!!this.hasTags() && (
-                        <Chips
-                            tags={this.props.tags.used}
-                            marked={this.props.tags.marked}
-                            toggleActive={this.toggleActive}
-                            removeTag={this.removeTag}
-                        />
-                    )}
+                <Downshift
+                    onStateChange={this.onStateChange}
+                    onSelect={this.onSelect}
+                    render={({
+                        getInputProps,
+                        getItemProps,
+                        isOpen,
+                        highlightedIndex
+                    }) => (
+                        <div>
+                            <div
+                                className={taggingClass}
+                                onMouseUp={this.onMouseUp}>
+                                {this.state.placeholder &&
+                                    !this.hasTags() && (
+                                        <div className={styles.placeholder}>
+                                            {localize('tagging', 'add_tags')}
+                                        </div>
+                                    )}
 
-                    <Taginput
-                        hasTags={!!this.hasTags()}
-                        inputRef={input => (this.input = input)}
-                        value={this.state.inputvalue}
-                        focused={this.state.focused}
-                        setValue={this.setInputValue}
-                        setFocus={this.setFocus}
-                        setBlur={this.setBlur}
-                        closePanel={this.props.closePanel}
-                        addTag={this.addTag}
-                        handleRemoveAction={this.handleRemoveAction}
-                        handleDirection={this.handleDirection}
-                        makeTagsInactive={this.makeTagsInactive}
-                    />
-                </div>
+                                {!!this.hasTags() && (
+                                    <Chips
+                                        tags={this.props.tags.used}
+                                        marked={this.props.tags.marked}
+                                        toggleActive={this.toggleActive}
+                                        removeTag={this.removeTag}
+                                    />
+                                )}
+
+                                <Taginput
+                                    typeaheadOpen={this.state.typeaheadOpen}
+                                    getInputProps={getInputProps}
+                                    hasTags={!!this.hasTags()}
+                                    inputRef={input => (this.input = input)}
+                                    value={this.state.inputvalue}
+                                    focused={this.state.focused}
+                                    setValue={this.setInputValue}
+                                    setFocus={this.setFocus}
+                                    setBlur={this.setBlur}
+                                    closePanel={this.props.closePanel}
+                                    addTag={this.addTag}
+                                    handleRemoveAction={this.handleRemoveAction}
+                                    makeTagsInactive={this.makeTagsInactive}
+                                    storedTags={this.storedTags}
+                                />
+                            </div>
+
+                            {isOpen ? (
+                                <div className={styles.typeaheadWrapper}>
+                                    <div className={styles.typeaheadList}>
+                                        {this.storedTags.map((item, index) => {
+                                            const itemStyle = cx({
+                                                typeahead: true,
+                                                active:
+                                                    highlightedIndex === index
+                                            })
+                                            return (
+                                                <div
+                                                    className={itemStyle}
+                                                    key={`item-${index}`}
+                                                    {...getItemProps({
+                                                        item,
+                                                        index
+                                                    })}>
+                                                    {item}
+                                                </div>
+                                            )
+                                        })}
+                                    </div>
+                                </div>
+                            ) : null}
+                        </div>
+                    )}
+                />
 
                 {this.props.tags &&
                     this.props.tags.suggested && (

--- a/src/containers/save/toolbar/tagging/tagging.scss
+++ b/src/containers/save/toolbar/tagging/tagging.scss
@@ -4,6 +4,7 @@
 .tagging {
     font-family: $fontstack-default;
     padding: 5px 0 0;
+    position: relative;
 }
 
 .well {
@@ -17,7 +18,7 @@
     box-sizing: border-box;
     font-size: 13px;
     line-height: 17px;
-    margin: 0 0 2px;
+    margin: 0;
     padding: 4px 10px 2px;
     position: relative;
     text-align: left;
@@ -35,3 +36,38 @@
     top: 6px;
 }
 
+.typeaheadWrapper {
+    position: relative;
+}
+
+.typeaheadList {
+    background: $white;
+    border: 1px solid $smoke;
+    border-radius: 0 0 3px 3px;
+    border-top: none;
+    box-shadow: 0 4px 4px rgba(0, 0, 0, 0.2);
+    box-sizing: border-box;
+    display: block;
+    left: 0;
+    list-style-type: none;
+    margin: 0;
+    max-height: 8.8em;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: 2px 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
+
+.typeahead {
+    cursor: pointer;
+    display: block;
+    padding: 2px 8px;
+
+    &:hover,
+    &.active {
+        background-color: $teal;
+        color: $white;
+    }
+}

--- a/src/containers/save/toolbar/tagging/taginput/taginput.js
+++ b/src/containers/save/toolbar/tagging/taginput/taginput.js
@@ -2,7 +2,8 @@ import styles from './taginput.scss'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { localize } from '../../../../../common/_locales/locales'
-
+import AutosizeInput from 'react-input-autosize'
+// import Downshift from 'downshift'
 import classNames from 'classnames/bind'
 const cx = classNames.bind(styles)
 
@@ -56,11 +57,8 @@ export default class Taginput extends Component {
                 return this.props.handleRemoveAction()
             case ESCAPE:
                 this.clearError()
+                this.props.setValue('')
                 return this.props.makeTagsInactive(true)
-            case DOWN:
-            case UP:
-                this.clearError()
-                return this.props.handleDirection(event.keyCode)
             default:
                 this.props.makeTagsInactive()
         }
@@ -73,6 +71,7 @@ export default class Taginput extends Component {
         }
 
         if (event.keyCode === ENTER) {
+            if (this.props.typeaheadOpen) return
             event.preventDefault()
             if (this.props.value) this.props.addTag(this.props.value)
             else this.props.closePanel()
@@ -85,7 +84,8 @@ export default class Taginput extends Component {
             event.keyCode !== LEFT &&
             event.keyCode !== UP &&
             event.keyCode !== RIGHT &&
-            event.keyCode !== DOWN
+            event.keyCode !== DOWN &&
+            event.keyCode !== ENTER
         ) {
             this.setError()
             event.preventDefault()
@@ -100,25 +100,26 @@ export default class Taginput extends Component {
         })
 
         return (
-            <div>
-                <input
-                    className={inputClass}
-                    type="text"
-                    ref={this.props.inputRef}
-                    value={this.props.value}
-                    onChange={this.onChange}
-                    onFocus={this.props.setFocus}
-                    onBlur={this.props.setBlur}
-                    onKeyUp={this.onKeyUp}
-                    onKeyDown={this.onInput}
-                    onKeyPress={this.onInput}
+            <React.Fragment>
+                <AutosizeInput
+                    {...this.props.getInputProps({
+                        inputClassName: inputClass,
+                        ref: this.props.inputRef,
+                        value: this.props.value,
+                        onChange: this.onChange,
+                        onFocus: this.props.setFocus,
+                        onBlur: this.props.setBlur,
+                        onKeyUp: this.onKeyUp,
+                        onKeyDown: this.onInput,
+                        onKeyPress: this.onInput
+                    })}
                 />
                 {this.state.error && (
                     <div className={styles.tagError}>
                         {localize('tagging', 'invalid_tags')}
                     </div>
                 )}
-            </div>
+            </React.Fragment>
         )
     }
 }

--- a/src/containers/save/toolbar/toolbar.main.js
+++ b/src/containers/save/toolbar/toolbar.main.js
@@ -6,22 +6,21 @@ import ToolbarError from './toolbar.error'
 import * as Icon from '../../../components/icons'
 import { localize } from '../../../common/_locales/locales'
 
-function getStatus(type, status){
+function getStatus(type, status) {
     if (status === 'saved') return localize('status', `${type}_${status}`)
     return localize('status', status)
 }
 
 class Toolbar extends Component {
-
-    constructor(props){
+    constructor(props) {
         super(props)
-        this.state ={
+        this.state = {
             hovered: false
         }
     }
 
-    onHover = () =>  {
-        if(!this.state.hovered){
+    onHover = () => {
+        if (!this.state.hovered) {
             this.hoverTimer = setTimeout(() => {
                 this.setState({ hovered: true })
             }, 500)
@@ -30,37 +29,38 @@ class Toolbar extends Component {
 
     offHover = () => {
         clearTimeout(this.hoverTimer)
-        if(this.state.hovered){
+        if (this.state.hovered) {
             this.setState({ hovered: false })
         }
     }
 
-    remove  = () => this.props.remove()
+    remove = () => this.props.remove()
     archive = () => this.props.archive()
 
+    get statusText() {
+        return getStatus(this.props.type, this.props.status)
+    }
 
-    get statusText(){ return getStatus(this.props.type, this.props.status) }
-
-    get listItems(){
+    get listItems() {
         return [
             {
-                copy: localize('actions','archive_page'),
+                copy: localize('actions', 'archive_page'),
                 icon: Icon.Archive,
                 method: this.archive
             },
             {
-                copy: localize('actions','remove_page'),
+                copy: localize('actions', 'remove_page'),
                 icon: Icon.Remove,
                 method: this.remove
             },
             {
-                copy: localize('actions','open_pocket'),
+                copy: localize('actions', 'open_pocket'),
                 icon: Icon.OpenPocket,
                 method: this.props.openPocket,
                 divider: true
             },
             {
-                copy: localize('actions','settings'),
+                copy: localize('actions', 'settings'),
                 icon: Icon.Settings,
                 method: this.props.openOptions
             }
@@ -68,41 +68,44 @@ class Toolbar extends Component {
     }
 
     render() {
-        const status    = this.props.status
-        const saveHash  = this.props.activeTab.hash
+        const status = this.props.status
+        const saveHash = this.props.activeTab.hash
 
         return (
-            <div className={styles.toolbar}
-                onMouseEnter = { this.onHover }
-                onMouseLeave = { this.offHover }>
-
-                {Icon.PocketLogo({width: '18px', height: '18px'})}
+            <div
+                className={styles.toolbar}
+                onMouseEnter={this.onHover}
+                onMouseLeave={this.offHover}>
+                {Icon.PocketLogo({ width: '18px', height: '18px' })}
                 {this.statusText}
 
-                { (status === 'error') && <ToolbarError /> }
+                {status === 'error' && <ToolbarError />}
 
-                { (status !== 'removed' && status !== 'error') &&
-                    <Dropdown
-                        tabId={this.props.tabId}
-                        active={this.props.dropDownActive}
-                        setStatus={this.props.setDropDownStatus}
-                        list={this.listItems}/>
-                }
+                {status !== 'removed' &&
+                    status !== 'error' && (
+                        <Dropdown
+                            tabId={this.props.tabId}
+                            active={this.props.dropDownActive}
+                            setStatus={this.props.setDropDownStatus}
+                            list={this.listItems}
+                        />
+                    )}
 
-                {(status === 'saved' || status === 'saving') &&
+                {(status === 'saved' || status === 'saving') && (
                     <Tagging
                         hovered={this.state.hovered}
                         tags={this.props.tags}
-                        activateTag={this.props.activateTag }
-                        deactivateTag={this.props.deactivateTag }
-                        addTag={this.props.addTag }
-                        deactivateTags={this.props.deactivateTags }
+                        activateTag={this.props.activateTag}
+                        deactivateTag={this.props.deactivateTag}
+                        addTag={this.props.addTag}
+                        deactivateTags={this.props.deactivateTags}
                         closePanel={this.props.closePanel}
-                        removeTag={this.props.removeTag }
-                        removeTags={this.props.removeTags }
+                        removeTag={this.props.removeTag}
+                        removeTags={this.props.removeTags}
                         saveHash={saveHash}
+                        storedTags={this.props.storedTags}
                     />
-                }
+                )}
             </div>
         )
     }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,4 +1,4 @@
-import { composeWithDevTools } from 'remote-redux-devtools'
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly'
 import { wrapStore } from 'react-chrome-redux'
 import { createStore, applyMiddleware } from 'redux'
 import createSagaMiddleware from 'redux-saga'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,6 +2048,10 @@ detect-port-alt@1.1.3:
     address "^1.0.1"
     debug "^2.6.0"
 
+diacritic@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/diacritic/-/diacritic-0.0.2.tgz#fc2a887b5a5bc0a0a854fb614c7c2f209061ee04"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -2155,6 +2159,10 @@ dot-prop@^4.1.1:
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
   dependencies:
     is-obj "^1.0.0"
+
+downshift@^1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.25.0.tgz#7f6e2dda4aa5ddbb2932401bd61e7b741e92c02e"
 
 duplexer@^0.1.1:
   version "0.1.1"
@@ -4182,6 +4190,12 @@ markdown-table@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.1.tgz#4b3dd3a133d1518b8ef0dbc709bf2a1b4824bc8c"
 
+match-sorter@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-2.2.0.tgz#3e88661aab7b8320836f67731cf7f9d3cb889761"
+  dependencies:
+    diacritic "0.0.2"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -5604,6 +5618,12 @@ react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
 
+react-input-autosize@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-motion@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.5.2.tgz#0dd3a69e411316567927917c6626551ba0607316"
@@ -5744,6 +5764,10 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-devtools-extension@^2.13.2:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz#e0f9a8e8dfca7c17be92c7124958a3b94eb2911d"
 
 redux-devtools-instrument@^1.3.3:
   version "1.8.2"


### PR DESCRIPTION
## Goal

Updating tagging to leverage open source libraries

Tagging now uses:

- downshift
- match-sorter
- react-input-autosize

## Todos:
- [x] Add Downshift for typeahead
- [x] Add Match-sorter for fuzzy matching
- [x] Refactor tagging to leverage these tools

## Implementation Decisions
Building a custom typeahead that was robust enough felt like wasted effort when so many excellent implementations exist.  Match Sorter added another layer of value.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
