### PR TITLE
Removing js injection on all sites

### DIFF
--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -28,8 +28,6 @@ content_scripts:
       - "*://*/*"
     css:
       - fonts/fonts.css
-    js:
-      - js/frame.bundle.js
   -
     matches:
       - '*://getpocket.com/extension_login_success'


### PR DESCRIPTION
## Goal

Fix collisions that occur with a pre-loaded iframe

## Todos:
- [x] Remove frame js from */* content_scripts

## Implementation Decisions

The way we traditionally injected content scripts into all sites caused some issue that were easily resolved my moving to an on-demand model.  Since we already had on-demand functionality in place to handle pages that existed prior to extension install, simply removing that script from the content_scripts in the manifest moves us to fully on-demand for all sites.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
