### PR TITLE
Fix/autocomplete trigger

### DIFF
--- a/src/common/utilities.js
+++ b/src/common/utilities.js
@@ -85,3 +85,7 @@ export function throttle(callback, wait, context = this) {
 export function getBool(value) {
     return value === 'true' || value === 1 || parseInt(value, 10) === 1
 }
+
+export function mergeDedupe(arrayOfArrays) {
+    return [...new Set([].concat(...arrayOfArrays))]
+}

--- a/src/containers/save/toolbar/tagging/tagging.js
+++ b/src/containers/save/toolbar/tagging/tagging.js
@@ -17,8 +17,7 @@ export default class Tagging extends Component {
         this.state = {
             placeholder: !this.hasTags(),
             inputvalue: '',
-            activeSuggestion: -1,
-            typeaheadOpen: false
+            activeSuggestion: -1
         }
     }
 
@@ -87,11 +86,6 @@ export default class Tagging extends Component {
         e.preventDefault()
     }
 
-    onStateChange = changes => {
-        if (typeof changes.isOpen !== 'undefined')
-            this.setState({ typeaheadOpen: changes.isOpen })
-    }
-
     onSelect = this.addTag
 
     get storedTags() {
@@ -117,7 +111,6 @@ export default class Tagging extends Component {
         return (
             <div className={styles.tagging}>
                 <Downshift
-                    onStateChange={this.onStateChange}
                     onSelect={this.onSelect}
                     render={({
                         getInputProps,
@@ -146,7 +139,7 @@ export default class Tagging extends Component {
                                 )}
 
                                 <Taginput
-                                    typeaheadOpen={this.state.typeaheadOpen}
+                                    highlightedIndex={highlightedIndex}
                                     getInputProps={getInputProps}
                                     hasTags={!!this.hasTags()}
                                     inputRef={input => (this.input = input)}
@@ -163,7 +156,7 @@ export default class Tagging extends Component {
                                 />
                             </div>
 
-                            {isOpen ? (
+                            {!isOpen ? null : (
                                 <div className={styles.typeaheadWrapper}>
                                     <div className={styles.typeaheadList}>
                                         {this.storedTags.map((item, index) => {
@@ -186,7 +179,7 @@ export default class Tagging extends Component {
                                         })}
                                     </div>
                                 </div>
-                            ) : null}
+                            )}
                         </div>
                     )}
                 />

--- a/src/containers/save/toolbar/tagging/taginput/taginput.js
+++ b/src/containers/save/toolbar/tagging/taginput/taginput.js
@@ -71,7 +71,7 @@ export default class Taginput extends Component {
         }
 
         if (event.keyCode === ENTER) {
-            if (this.props.typeaheadOpen) return
+            if (this.props.highlightedIndex != null) return
             event.preventDefault()
             if (this.props.value) this.props.addTag(this.props.value)
             else this.props.closePanel()

--- a/src/containers/save/toolbar/tagging/taginput/taginput.js
+++ b/src/containers/save/toolbar/tagging/taginput/taginput.js
@@ -45,7 +45,6 @@ export default class Taginput extends Component {
     /* Input Events
     –––––––––––––––––––––––––––––––––––––––––––––––––– */
     onChange = event => {
-        event.preventDefault()
         this.props.setValue(event.target.value)
     }
 


### PR DESCRIPTION
## Goal

This updates auto-complete to fire when the user begins to type as opposed to when they select the down or up arrows.  

This also addresses a bug where you are unable to add a tag with the enter key if there are no tags selected but the typeahead is open.

## Todos:
- [x] Update Trigger - Remove preventDefault()
- [x] Update event handling on enter key
- [x] Remove explicit typeaheadOpen in favor of checking highlighedIndex
- [x] Update reference to tags stored pre-3.0 - Merge tags and stored_tags without duplicates 

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
