### PR TITLE
Update/Eliminate pre-emptive tab storage

### DIFF
--- a/src/containers/background/_tabs.js
+++ b/src/containers/background/_tabs.js
@@ -23,11 +23,9 @@ export const active = (state = 0, action) => {
         case 'REQUEST_SAVE_TO_POCKET': {
             return action.tabId
         }
+        case 'ACTIVE_WINDOW_CHANGED':
         case 'ACTIVE_TAB_CHANGED': {
             return action.tabInfo.tabId
-        }
-        case 'ACTIVE_WINDOW_CHANGED': {
-            return action.tabId
         }
         default:
             return state
@@ -42,15 +40,7 @@ export const tabs = (state = {}, action) => {
         }
 
         case 'ACTIVE_TAB_UPDATED': {
-            return {
-                ...state,
-                [action.tabId]: {
-                    frame: action.frame,
-                    status: 'idle',
-                    shown: false,
-                    dropDownActive: false
-                }
-            }
+            return setTabsUpdate(state, action)
         }
 
         case 'FRAME_LOADED': {
@@ -184,4 +174,17 @@ function setTabsIdle(tabs) {
         return null
     })
     return idleTabs || {}
+}
+
+function setTabsUpdate(state, action) {
+    if (!state[action.tabId]) return state
+    return {
+        ...state,
+        [action.tabId]: {
+            frame: action.frame,
+            status: 'idle',
+            shown: false,
+            dropDownActive: false
+        }
+    }
 }

--- a/src/containers/background/background.js
+++ b/src/containers/background/background.js
@@ -157,7 +157,9 @@ function setTabListeners() {
             if (tab[0])
                 store.dispatch({
                     type: 'ACTIVE_WINDOW_CHANGED',
-                    tabId: tab[0].id
+                    tabInfo: {
+                        tabId: tab[0].id
+                    }
                 })
         })
     })


### PR DESCRIPTION

## Goal

Tabs would be marked as `ready` after being loaded.  This had the potential to cause high memory consumption on a user with a great many tabs open.  This is being switched to a less aggressive version where we only text readiness on a save request.  We drop tabs when they are closed.

## Todos:
- [x] Adjust `ACTIVE_TAB_UPDATED` to only handle existing tabs from previous saves
- [x] Adjust `ACTIVE_WINDOW_CHANGED` And `ACTIVE_TAB_CHANGED` to be consistent in the shape of their returns

## Implementation Decisions
The initial idea was operating under the assumption of a certain number of tabs.  This eliminates that assumption and take into account users with high volume of tabs.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
