### PR TITLE
Release 3.0.0.11

### DIFF
--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -1,5 +1,5 @@
 name: 'Save to Pocket'
-version: 3.0.0.10
+version: 3.0.0.11
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"


### PR DESCRIPTION
## Goal

Release 3.0.0.11

## Todos:
- [x] Update Manifest to 3.0.0.11
- [x] Compose Changelog

## Change Log

### Improvements 
-  Eliminate pre-emptive tab storage (#30)
    *  Tabs would be marked as `ready` after being loaded.  This had the potential to cause high memory consumption on a user with a great many tabs open.  This is being switched to a less aggressive version where we only test readiness on a save request. 

### Fixes
- Fix/autocomplete trigger (#29)
    * Updating `Enter` check for highlightedIndex
    * Fix autocomplete now shows on first letter input
    * Updating tag storage to utilize existing tags
        - This add the existing `tags` to the `stored_tags` and removes the `tags` from the local storage.  Basically just changing the key for stored tags.
    * Fixing close panel on double enter - Removed the delay in close on double enter.
    * Updating typeahead open trigger to include result check
-  Fix/item tag association (#31)
    *  Updating how the save data is being built - On certain sites the data returned from the server is not a complete set.  This updates the object with cascading selection of data.
    *  Update tag syncing
        1. Grabbing the current tab info prior to yielding the delay to avoid invalidating the tag save process
        2. Updating the API to send `item_id` as opposed to `url`

## Implementation Decisions
We are moving to a release PR to avoid sloppy versioning and cut corners.  This will also be a place to do any cleanup to prep the release

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
