### PR TITLE
Adding tag fetch from server when user logs in

### DIFF
--- a/src/common/api/index.js
+++ b/src/common/api/index.js
@@ -1,7 +1,7 @@
 import { request } from './_request/request'
 import { saveToPocket } from './saving/save'
 import { getRecommendations } from './saving/recommendations'
-import { getOnSaveTags, syncItemTags } from './saving/tags'
+import { getOnSaveTags, syncItemTags, fetchStoredTags } from './saving/tags'
 import { archiveItem } from './saving/archive'
 import { removeItem } from './saving/remove'
 import { authorize } from './auth/authorize'
@@ -9,7 +9,6 @@ import { getGuid } from './auth/guid'
 import { getTrendingArticles } from './newtab/trendingArticles'
 import { getTrendingTopics } from './newtab/trendingTopics'
 import { sendAnalytics } from './analytics/analytics'
-
 
 export {
     authorize,
@@ -23,5 +22,6 @@ export {
     getTrendingArticles,
     getTrendingTopics,
     sendAnalytics,
-    syncItemTags
+    syncItemTags,
+    fetchStoredTags
 }

--- a/src/common/api/saving/tags.js
+++ b/src/common/api/saving/tags.js
@@ -19,3 +19,15 @@ export function syncItemTags(id, tags) {
         }
     }).then(response => response)
 }
+
+export function fetchStoredTags(since) {
+    return request({
+        path: 'get/',
+        data: {
+            tags: 1,
+            taglist: 1,
+            account: 1,
+            since: since ? since : 0
+        }
+    }).then(response => response)
+}

--- a/src/store/combineSagas.js
+++ b/src/store/combineSagas.js
@@ -6,6 +6,8 @@ import { wSetup } from '../containers/background/_setup'
 import { wHydrate } from '../containers/background/_setup'
 import { wToggleRecs } from '../containers/background/_setup'
 import { wToggleSite } from '../containers/background/_setup'
+import { wUserLoggedIn } from '../containers/background/_setup'
+
 import { wSaveTweet } from '../containers/background/_sites'
 
 import { wAuthCodeRecieved } from '../containers/auth/_auth'
@@ -37,6 +39,7 @@ export default function* rootSaga() {
         wToggleRecs(),
         wToggleSite(),
         wSaveTweet(),
+        wUserLoggedIn(),
 
         wOpenPocket(),
         wOpenOptions(),


### PR DESCRIPTION
## Goal

When a user logs in the extension fetches previously used tags from the server to hydrate autocomplete tagging list.

## Todos:
- [x] Add FetchTags to API
- [x] Add Saga for making call to API
- [x] Setup watch on USER_LOGGED_IN
- [x] Hydrate Tags on successful fetch
- [x] Store tags locally
- [x] Store fetchedSince

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
