### PR TITLE
Updating Manifest to 3.0.0.12

### DIFF
--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -1,5 +1,5 @@
 name: 'Save to Pocket'
-version: 3.0.0.11
+version: 3.0.0.12
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"


### PR DESCRIPTION
## Goal

Release 3.0.0.12

## Todos:
- [x] Update Manifest to 3.0.0.12
- [x] Compose Changelog

## Change Log

### Fixes
-  Adding tag fetch from server when user logs in (#35)
    *  When a user logs in, the extension fetches previously used tags from the server to hydrate autocomplete tagging list.  This should not affect pre-existing users as we also store these tags locally.  For fresh installs, users will not have their previous tags available to them immediately.  This fixes a regression introduced in 3.0.0.x


## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

