### PR TITLE
Update/caching cpu usage

### DIFF
--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -13,6 +13,10 @@ export function isNewTab(tab, url) {
     )
 }
 
+export function isSystemPage(tab, url) {
+    return tab.active && tab.url.startsWith('chrome://')
+}
+
 export function getBaseUrl() {
     const baseURLSetting = getSetting('base_URL')
     if (!baseURLSetting) setSettings({ base_URL: 'https://getpocket.com/' })

--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -14,7 +14,11 @@ export function isNewTab(tab, url) {
 }
 
 export function isSystemPage(tab, url) {
-    return tab.active && tab.url.startsWith('chrome://')
+    return (
+        tab.active &&
+        (tab.url.startsWith('chrome://') ||
+            tab.url.startsWith('chrome-extension://'))
+    )
 }
 
 export function getBaseUrl() {

--- a/src/common/interface.js
+++ b/src/common/interface.js
@@ -50,6 +50,10 @@ export function onTabRemoved(callback) {
     return chrome.tabs.onRemoved.addListener(callback)
 }
 
+export function onTabReplaced(callback) {
+    return chrome.tabs.onReplaced.addListener(callback)
+}
+
 export function onFocusChanged(callback) {
     return chrome.windows.onFocusChanged.addListener(callback)
 }

--- a/src/common/interface.js
+++ b/src/common/interface.js
@@ -11,7 +11,7 @@ export function addMessageListener(handler) {
 }
 
 export function removeMessageListener(handler) {
-    return chrome.runtime.onMessage.removeListner(handler)
+    return chrome.runtime.onMessage.removeListener(handler)
 }
 
 export function onUpdateAvailable(handler) {

--- a/src/containers/background/_setup.js
+++ b/src/containers/background/_setup.js
@@ -2,7 +2,6 @@ import { put, takeLatest, select, call } from 'redux-saga/effects'
 import {
     getSetting,
     setSettings,
-    getCommands,
     removeSettings
 } from '../../common/interface'
 import { getBool, mergeDedupe } from '../../common/utilities'
@@ -13,8 +12,6 @@ const initialState = {
     base_api_version: 'v3/',
     base_loglevel: 'DEFAULT',
     base_URL: 'https://getpocket.com/',
-
-    key_shortcuts: undefined,
 
     base_installed: 1,
 
@@ -118,7 +115,6 @@ function* initSetup() {
 }
 
 function* hydrateState() {
-    const keyShortcutArray = yield call(getCommands)
 
     // Consolidate tags: Remove this in 3.0.1.0
     const tags = JSON.parse(getSetting('tags')) || []
@@ -139,7 +135,6 @@ function* hydrateState() {
         account_name_last: getSetting('account_name_last'),
         account_avatar: getSetting('account_avatar'),
         account_premium: getBool(getSetting('account_premium')),
-        key_shortcuts: keyShortcutArray,
         on_save_recommendations: getBool(getSetting('on_save_recommendations')),
         sites_facebook: getBool(getSetting('sites_facebook')),
         sites_hackernews: getBool(getSetting('sites_hackernews')),

--- a/src/containers/background/_tabs.js
+++ b/src/containers/background/_tabs.js
@@ -42,6 +42,9 @@ export const tabs = (state = {}, action) => {
         case 'ACTIVE_TAB_UPDATED': {
             return setTabsUpdate(state, action)
         }
+        case 'TAB_REPLACED': {
+            return setTabSwap(state, action)
+        }
 
         case 'FRAME_LOADED': {
             return {
@@ -174,6 +177,17 @@ function setTabsIdle(tabs) {
         return null
     })
     return idleTabs || {}
+// Reducer Utilities
+function setTabSwap(state, action) {
+    const newState = {
+        ...state,
+        [action.addedTab]: {
+            ...[action.removedTab]
+        }
+    }
+
+    delete newState[action.removedTab]
+    return newState
 }
 
 function setTabsUpdate(state, action) {

--- a/src/containers/background/_tabs.js
+++ b/src/containers/background/_tabs.js
@@ -1,4 +1,5 @@
 import { put, takeEvery, select } from 'redux-saga/effects'
+import { sendMessageToTab } from '../../common/interface'
 
 // ACTIONS
 export const tabsActions = {
@@ -207,17 +208,15 @@ export function* wTabChanges() {
 }
 
 const getActive = state => {
-    return {
-        active: state.active,
-        tabs: state.tabs
-    }
+    return state.active
 }
 
 function* tabChanges(action) {
-    const { active, tabs } = yield select(getActive)
-    const activeTab = tabs[active]
-    if (active && activeTab && activeTab.status !== 'idle') {
-        yield put({ type: 'SET_TAB_IDLE', active })
-    }
+    const active = yield select(getActive)
+
+    yield put({ type: 'CANCEL_CLOSE_SAVE_PANEL' })
+    sendMessageToTab(active, { type: 'frameUnload' })
+    yield put({ type: 'TAB_CLOSED', tabId: active })
+
     yield put({ type: 'SET_TAB_ACTIVE', tabId: action.tabInfo.tabId })
 }

--- a/src/containers/background/_tabs.js
+++ b/src/containers/background/_tabs.js
@@ -78,12 +78,8 @@ export const tabs = (state = {}, action) => {
         }
 
         case 'TAB_CLOSED': {
-            const filteredState = Object.keys(state)
-                .filter(key => parseInt(key, 10) !== action.tabId)
-                .reduce((accumulator, key) => {
-                    accumulator[key] = state[key]
-                    return accumulator
-                }, {})
+            const filteredState = state
+            delete filteredState[action.tabId]
             return filteredState
         }
 

--- a/src/containers/background/background.js
+++ b/src/containers/background/background.js
@@ -152,7 +152,7 @@ function setTabListeners() {
         })
     })
 
-    Interface.onFocusChanged(object => {
+    Interface.onFocusChanged(() => {
         Interface.getCurrentTab(tab => {
             if (tab[0])
                 store.dispatch({
@@ -166,6 +166,10 @@ function setTabListeners() {
 
     Interface.onTabRemoved((tabId, removeInfo) => {
         store.dispatch({ type: 'TAB_CLOSED', tabId, removeInfo: removeInfo })
+    })
+
+    Interface.onTabReplaced((addedTabId, removedTabId) => {
+        store.dispatch({ type: 'TAB_REPLACED', addedTabId, removedTabId })
     })
 }
 

--- a/src/containers/background/background.js
+++ b/src/containers/background/background.js
@@ -1,6 +1,6 @@
 import { Framer } from '../save/frame/framer'
 import * as Interface from '../../common/interface'
-import { isNewTab, getBaseUrl } from '../../common/helpers'
+import { isNewTab, getBaseUrl, isSystemPage } from '../../common/helpers'
 import { initializeStore } from '../../store/store'
 import { closeSavePanel } from '../../store/combineActions'
 import { cancelCloseSavePanel } from '../../store/combineActions'
@@ -112,7 +112,7 @@ function takeContextAction(info, tab) {
 
 function setBrowserAction() {
     Interface.browserAction().onClicked.addListener((tab, url) => {
-        if (isNewTab(tab, url))
+        if (isNewTab(tab, url) || isSystemPage(tab, url))
             return Interface.openUrl(getBaseUrl() + 'a/?s=ext_rc_open')
 
         checkTabInjection(tab).then(response => {

--- a/src/containers/save/_save.js
+++ b/src/containers/save/_save.js
@@ -218,7 +218,6 @@ function buildSaveObject(action) {
             const saveType = 'page'
             const actionInfo = { cxt_ui: 'toolbar' }
             const showSavedIcon = true
-            // const saveHash = md5(tab.url)
 
             return {
                 tabId,
@@ -227,7 +226,6 @@ function buildSaveObject(action) {
                 saveType,
                 actionInfo,
                 showSavedIcon
-                // saveHash
             }
         }
         case 'context': {
@@ -244,7 +242,6 @@ function buildSaveObject(action) {
             const saveType = savedLink ? 'link' : 'page'
             const actionInfo = { cxt_ui, cxt_url: tab.url }
             const showSavedIcon = savedLink ? 0 : 1
-            // const saveHash = md5(tab.url)
 
             return {
                 tabId,
@@ -253,7 +250,6 @@ function buildSaveObject(action) {
                 saveType,
                 actionInfo,
                 showSavedIcon
-                // saveHash
             }
         }
         default:

--- a/src/containers/save/_save.js
+++ b/src/containers/save/_save.js
@@ -115,7 +115,13 @@ function* saveRequest(action) {
     const data = yield call(saveToPocket, saveObject, authToken)
 
     if (data) {
-        yield put({ type: 'SAVE_TO_POCKET_SUCCESS', tabId, saveHash, data })
+        yield put({
+            type: 'SAVE_TO_POCKET_SUCCESS',
+            tabId,
+            saveHash,
+            data,
+            inception: Date.now()
+        })
         yield saveSuccess(saveObject, data.response.resolved_id)
     } else {
         yield put({ type: 'SAVE_TO_POCKET_FAILURE', tabId, saveHash })

--- a/src/containers/save/_save.js
+++ b/src/containers/save/_save.js
@@ -103,6 +103,8 @@ function* closePanel(tabId, timeout) {
 }
 
 function* saveRequest(action) {
+    yield put({ type: 'CANCEL_CLOSE_SAVE_PANEL' })
+
     const saveType =
         action.data.info && action.data.info.linkUrl ? 'link' : 'page'
     const tabId = action.data.tab.id

--- a/src/containers/save/_save.js
+++ b/src/containers/save/_save.js
@@ -45,12 +45,8 @@ export const saves = (state = initialState, action) => {
         }
 
         case 'TAB_CLOSED': {
-            const filteredState = Object.keys(state)
-                .filter(key => parseInt(key, 10) !== action.tabId)
-                .reduce((accumulator, key) => {
-                    accumulator[key] = state[key]
-                    return accumulator
-                }, {})
+            const filteredState = state
+            delete filteredState[action.tabId]
             return filteredState
         }
 

--- a/src/containers/save/frame/frame.js
+++ b/src/containers/save/frame/frame.js
@@ -17,6 +17,7 @@ import {
     frame.style.float = 'none'
     frame.style.width = '335px'
     frame.style.zIndex = 2147483647
+    frame.style.background = 'transparent'
 
     // frame.style.transition     = 'height 250ms'
     // frame.style.backgroundColor= 'rgba(0,0,255, 0.5)' //DEV ONLY

--- a/src/containers/save/frame/frame.js
+++ b/src/containers/save/frame/frame.js
@@ -1,10 +1,12 @@
 import {
     getURL,
     addMessageListener,
+    removeMessageListener,
     sendMessage
 } from '../../../common/interface'
-;(function(getURL, addMessageListener, sendMessage) {
+;(function(getURL, addMessageListener, removeMessageListener, sendMessage) {
     let frame = document.createElement('iframe')
+    let element
 
     frame.style.border = 'none'
     frame.style.display = 'block'
@@ -36,7 +38,7 @@ import {
         frame.setAttribute('allowtransparency', true)
         frame.src = getURL('save.html')
 
-        document.body.appendChild(frame)
+        element = document.body.appendChild(frame)
     }
 
     function handleAction(action, sender, sendResponse) {
@@ -51,6 +53,10 @@ import {
         if (action.type === 'frameShift') {
             frame.style.height = `${action.value}px`
         }
+
+        if (action.type === 'frameUnload') {
+            unloadFrame()
+        }
     }
 
     function render() {
@@ -64,5 +70,10 @@ import {
         })
     }
 
+    function unloadFrame() {
+        removeMessageListener(handleAction)
+        element.remove()
+    }
+
     render()
-})(getURL, addMessageListener, sendMessage)
+})(getURL, addMessageListener, removeMessageListener, sendMessage)

--- a/src/containers/save/frame/framer.js
+++ b/src/containers/save/frame/framer.js
@@ -1,4 +1,4 @@
-import { sendMessageToAllTabs } from '../../../common/interface'
+import { sendMessageToTab } from '../../../common/interface'
 
 function frameObserver(store, onChange) {
     let currentState
@@ -25,7 +25,8 @@ function selectPanelHeight(state) {
     const recCount = recs ? recs.feed.length : 0
 
     const tags = state.tags[state.active]
-    const tagsSize = tags ? tags.used.join(',').split('').length : 0
+    const tagsSize =
+        tags && tags.used ? tags.used.join(',').split('').length : 0
     const tagHeight = Math.max(tagsSize / 27, 0) * 32
 
     const suggestions = tags && tags.suggested ? tags.suggested.length : 0
@@ -76,11 +77,15 @@ export class Framer {
         this.store = store
     }
 
-    checkDimensions(frameHeight) {
-        sendMessageToAllTabs({
-            type: 'frameShift',
-            value: frameHeight
-        })
+    checkDimensions = frameHeight => {
+        const state = this.store.getState()
+        const tabId = state.active
+        if(tabId){
+            sendMessageToTab(tabId, {
+                type: 'frameShift',
+                value: frameHeight
+            })
+        }
     }
 
     watch() {

--- a/src/containers/save/frame/framer.js
+++ b/src/containers/save/frame/framer.js
@@ -5,10 +5,8 @@ function frameObserver(store, onChange) {
 
     function handleChange() {
         let nextState = selectPanelHeight(store.getState())
-        // if (nextState !== currentState) {
         currentState = nextState
         onChange(currentState)
-        // }
     }
 
     let unsubscribe = store.subscribe(handleChange)
@@ -22,12 +20,11 @@ function selectPanelHeight(state) {
 
     const frameLoad = activeTab.frame === 'loaded' ? 0 : -1
 
-    const hash = activeTab.hash
     const status = activeTab.status
-    const recs = state.recommendations[hash]
+    const recs = state.recommendations[state.active]
     const recCount = recs ? recs.feed.length : 0
 
-    const tags = state.tags[hash]
+    const tags = state.tags[state.active]
     const tagsSize = tags ? tags.used.join(',').split('').length : 0
     const tagHeight = Math.max(tagsSize / 27, 0) * 32
 

--- a/src/containers/save/recommendations/_recommendations.js
+++ b/src/containers/save/recommendations/_recommendations.js
@@ -39,6 +39,13 @@ export const recommendations = (state = {}, action) => {
             return state
         }
 
+        case 'REQUEST_SAVE_TO_POCKET': {
+            return {
+                ...state,
+                [action.tabId]: undefined
+            }
+        }
+
         case 'RECOMMENDATIONS_SUCCESS': {
             return {
                 ...state,
@@ -50,12 +57,13 @@ export const recommendations = (state = {}, action) => {
         }
 
         case 'REQUEST_SAVE_REC_TO_POCKET': {
-            const feed = state[action.tabId].feed
+            const tabId = action.data.tabId
+            const feed = state[tabId].feed
             const id = action.data.id
             return {
                 ...state,
-                [action.tabId]: {
-                    ...state[action.tabId],
+                [tabId]: {
+                    ...state[tabId],
                     feed: setFeedItemStatus(feed, id, 'saving')
                 }
             }
@@ -116,7 +124,6 @@ function* getRecommendations(action) {
             yield put({
                 type: 'RECOMMENDATIONS_SUCCESS',
                 data,
-                saveHash: action.saveObject.saveHash,
                 tabId: action.saveObject.tabId
             })
         } else {
@@ -147,20 +154,20 @@ function* saveRecommendation(action) {
             ? yield put({
                   type: 'SAVE_RECOMMENDATION_SUCCESS',
                   data,
-                  hash: action.data.hash,
+                  tabId: action.data.tabId,
                   id: action.data.id
               })
             : yield put({
                   type: 'SAVE_RECOMMENDATION_FAILURE',
                   status: 'not ok',
-                  hash: action.data.hash,
+                  tabId: action.data.tabId,
                   id: action.data.id
               })
     } else {
         yield put({
             type: 'SAVE_RECOMMENDATION_FAILURE',
             status: 'timeout',
-            hash: action.data.hash,
+            tabId: action.data.tabId,
             id: action.data.id
         })
     }

--- a/src/containers/save/recommendations/_recommendations.js
+++ b/src/containers/save/recommendations/_recommendations.js
@@ -62,12 +62,8 @@ export const recommendations = (state = {}, action) => {
         }
 
         case 'TAB_CLOSED': {
-            const filteredState = Object.keys(state)
-                .filter(key => parseInt(key, 10) !== action.tabId)
-                .reduce((accumulator, key) => {
-                    accumulator[key] = state[key]
-                    return accumulator
-                }, {})
+            const filteredState = state
+            delete filteredState[action.tabId]
             return filteredState
         }
 

--- a/src/containers/save/recommendations/header/header.js
+++ b/src/containers/save/recommendations/header/header.js
@@ -4,37 +4,38 @@ import Loading from './loading'
 import { localize } from '../../../../common/_locales/locales'
 
 const hasRecs = recs => recs
-const hasFeed = recs => recs && recs.feed.length > 0
+const hasFeed = recs => recs && recs.feed && recs.feed.length > 0
 
-export default function Header( recs ){
+export default function Header(recs) {
     return (
         <div>
-            {!hasRecs(recs) &&
-                <Loading />
-            }
+            {!hasRecs(recs) && <Loading />}
 
-            {hasRecs(recs) &&
+            {hasRecs(recs) && (
                 <div>
-                    {hasFeed(recs) &&
+                    {hasFeed(recs) && (
                         <div className={styles.header}>
-                            { recs.reason
-                                ? `${localize('recommendations','more_on')} ${recs.reason}`
-                                : localize('recommendations','explore')
-                            }
+                            {recs.reason
+                                ? `${localize('recommendations', 'more_on')} ${
+                                      recs.reason
+                                  }`
+                                : localize('recommendations', 'explore')}
                         </div>
-                    }
+                    )}
 
-                    {!hasFeed(recs) &&
+                    {!hasFeed(recs) && (
                         <div className={styles.header}>
                             {localize('recommendations', 'more_stories_detail')}
-                            <a href="https://getpocket.com/a/recommended/?src=ext_recs"
-                                rel="noopener noreferrer" target="_blank">
-                                {localize('recommendations','explore')}
+                            <a
+                                href="https://getpocket.com/a/recommended/?src=ext_recs"
+                                rel="noopener noreferrer"
+                                target="_blank">
+                                {localize('recommendations', 'explore')}
                             </a>
                         </div>
-                    }
+                    )}
                 </div>
-            }
+            )}
         </div>
     )
 }

--- a/src/containers/save/recommendations/list/item.js
+++ b/src/containers/save/recommendations/list/item.js
@@ -62,7 +62,7 @@ export default class RecommendationItem extends Component {
                         className={saveButtonClass}
                         onClick={() =>
                             this.props.saveRecommendation({
-                                hash: this.props.hash,
+                                tabId: this.props.tabId,
                                 id: item.id,
                                 title: item.title,
                                 url: item.url

--- a/src/containers/save/recommendations/list/list.js
+++ b/src/containers/save/recommendations/list/list.js
@@ -48,9 +48,12 @@ export default class RecommendationList extends Component {
                                 motionStyle={config.style}
                                 key={config.key}
                                 item={config.data}
-                                saveRecommendation={this.props.saveRecommendation}
-                                hash={this.props.hash}/>
-                        )}
+                                saveRecommendation={
+                                    this.props.saveRecommendation
+                                }
+                                tabId={this.props.tabId}
+                            />
+                        ))}
                     </ul>
                 }
             </TransitionMotion>

--- a/src/containers/save/recommendations/list/list.js
+++ b/src/containers/save/recommendations/list/list.js
@@ -1,38 +1,42 @@
 import styleClass from './item.scss'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import {TransitionMotion, spring, presets} from 'react-motion'
+import { TransitionMotion, spring, presets } from 'react-motion'
 import RecommendationItem from './item'
 
 export default class RecommendationList extends Component {
     // actual animation-related logic
     getDefaultStyles = () => {
-        return this.props.list.map( rec => {
+        return this.props.list.map(rec => {
             return {
                 ...rec,
                 data: rec,
-                key: 'id'+rec.id,
-                style: {height: 0, opacity: 0}
+                key: 'id' + rec.id,
+                style: { height: 0, opacity: 0 }
             }
         })
     }
 
     getStyles = () => {
-        return this.props.list.map( rec => {
+        return this.props.list.map(rec => {
             return {
                 ...rec,
                 data: rec,
-                key: 'id'+rec.id,
+                key: 'id' + rec.id,
                 style: {
-                    height: spring(110, {stiffness: 500, damping: 25}),
-                    opacity: spring(1, presets.stiff),
+                    height: spring(110, { stiffness: 150, damping: 14 }),
+                    opacity: spring(1, presets.stiff)
                 }
             }
         })
     }
 
-    willEnter() { return { height: 0, opacity: 0 } }
-    willLeave() { return { height: spring(0), opacity: spring(0) } }
+    willEnter() {
+        return { height: 0, opacity: 0 }
+    }
+    willLeave() {
+        return { height: spring(0), opacity: spring(0) }
+    }
 
     render() {
         return (
@@ -41,9 +45,9 @@ export default class RecommendationList extends Component {
                 styles={this.getStyles()}
                 willLeave={this.willLeave}
                 willEnter={this.willEnter}>
-                { interpolatedStyles =>
+                {interpolatedStyles => (
                     <ul className={styleClass.list}>
-                        {interpolatedStyles.map(config =>
+                        {interpolatedStyles.map(config => (
                             <RecommendationItem
                                 motionStyle={config.style}
                                 key={config.key}
@@ -55,13 +59,14 @@ export default class RecommendationList extends Component {
                             />
                         ))}
                     </ul>
-                }
+                )}
             </TransitionMotion>
-        )}
+        )
+    }
 }
 
 RecommendationList.propTypes = {
-    list        : PropTypes.array,
-    recs        : PropTypes.object,
-    saveRec     : PropTypes.func
+    list: PropTypes.array,
+    recs: PropTypes.object,
+    saveRec: PropTypes.func
 }

--- a/src/containers/save/recommendations/recommendations.main.js
+++ b/src/containers/save/recommendations/recommendations.main.js
@@ -15,7 +15,7 @@ export default class Recommendations extends Component {
 
                 {this.props.recs && (
                     <RecommendationList
-                        hash={this.props.hash}
+                        tabId={this.props.tabId}
                         saveRecommendation={this.props.saveRecommendation}
                         list={this.props.recs.feed}
                     />

--- a/src/containers/save/save.app.js
+++ b/src/containers/save/save.app.js
@@ -126,7 +126,7 @@ class App extends Component {
                     closePanel={this.closePanel}
                     removeTag={this.props.removeTag}
                     removeTags={this.props.removeTags}
-                    setup={this.props.setup.tags_stored}
+                    setup={this.props.setup}
                     inputFocused={this.state.inputFocused}
                     setInputFocusState={this.setInputFocusState}
                     currentRecs={this.currentRecs}

--- a/src/containers/save/save.app.js
+++ b/src/containers/save/save.app.js
@@ -1,11 +1,6 @@
-import styles from './save.scss' // Import Styles
 import React, { Component } from 'react'
+import SaveContainer from './save.container'
 
-import Toolbar from './toolbar/toolbar.main'
-import Recommendations from './recommendations/recommendations.main'
-import classNames from 'classnames/bind'
-
-const cx = classNames.bind(styles)
 const activeState = [
     'saved',
     'saving',
@@ -108,49 +103,35 @@ class App extends Component {
     }
 
     render() {
-        const panelClass = cx({
-            hanger: true,
-            active: this.isSaveActive()
-        })
-
         return (
-            <div
-                className={panelClass}
-                onMouseEnter={this.onHover}
-                onMouseLeave={this.offHover}>
-                {this.isSaveActive() && (
-                    <Toolbar
-                        tabId={this.props.tab_id}
-                        dropDownActive={this.currentTab.dropDownActive}
-                        setDropDownStatus={this.props.setDropDownStatus}
-                        openPocket={this.props.openPocket}
-                        openOptions={this.props.openOptions}
-                        archive={this.props.archiveItem}
-                        remove={this.props.removeItem}
-                        activeTab={this.currentTab}
-                        type={this.currentTab.type}
-                        status={this.currentTab.status}
-                        active={this.props.active}
-                        tags={this.currentTags}
-                        activateTag={this.props.activateTag}
-                        deactivateTag={this.props.deactivateTag}
-                        deactivateTags={this.props.deactivateTags}
-                        addTag={this.props.addTag}
-                        closePanel={this.closePanel}
-                        removeTag={this.props.removeTag}
-                        removeTags={this.props.removeTags}
-                        storedTags={this.props.setup.tags_stored}
-                        inputFocused={this.state.inputFocused}
-                        setInputFocusState={this.setInputFocusState}
-                    />
-                )}
-                {this.showRecs && (
-                    <Recommendations
-                        hash={this.currentTab.hash}
-                        recs={this.currentRecs}
-                        saveRecommendation={this.props.saveRecommendation}
-                    />
-                )}
+            <div>
+                <SaveContainer
+                    isSaveActive={this.isSaveActive()}
+                    showRecs={this.showRecs}
+                    onHover={this.onHover}
+                    offHover={this.offHover}
+                    tab_id={this.props.tab_id}
+                    currentTab={this.currentTab}
+                    setDropDownStatus={this.props.setDropDownStatus}
+                    openPocket={this.props.openPocket}
+                    openOptions={this.props.openOptions}
+                    archiveItem={this.props.archiveItem}
+                    removeItem={this.props.removeItem}
+                    active={this.props.active}
+                    currentTags={this.currentTags}
+                    activateTag={this.props.activateTag}
+                    deactivateTag={this.props.deactivateTag}
+                    deactivateTags={this.props.deactivateTags}
+                    addTag={this.props.addTag}
+                    closePanel={this.closePanel}
+                    removeTag={this.props.removeTag}
+                    removeTags={this.props.removeTags}
+                    setup={this.props.setup.tags_stored}
+                    inputFocused={this.state.inputFocused}
+                    setInputFocusState={this.setInputFocusState}
+                    currentRecs={this.currentRecs}
+                    saveRecommendation={this.props.saveRecommendation}
+                />
             </div>
         )
     }

--- a/src/containers/save/save.app.js
+++ b/src/containers/save/save.app.js
@@ -96,15 +96,15 @@ class App extends Component {
     }
 
     get currentSave() {
-        return this.props.saves[this.currentTab.hash]
+        return this.props.saves[this.props.active]
     }
 
     get currentRecs() {
-        return this.props.recommendations[this.currentTab.hash]
+        return this.props.recommendations[this.props.active]
     }
 
     get currentTags() {
-        return this.props.tags[this.currentTab.hash]
+        return this.props.tags[this.props.active]
     }
 
     render() {

--- a/src/containers/save/save.container.js
+++ b/src/containers/save/save.container.js
@@ -99,6 +99,7 @@ class SaveContainer extends Component {
                                         />
                                         {this.props.showRecs && (
                                             <Recommendations
+                                                tabId={this.props.tab_id}
                                                 recs={this.props.currentRecs}
                                                 saveRecommendation={
                                                     this.props

--- a/src/containers/save/save.container.js
+++ b/src/containers/save/save.container.js
@@ -63,10 +63,6 @@ class SaveContainer extends Component {
                                         }}>
                                         <Toolbar
                                             tabId={this.props.tab_id}
-                                            dropDownActive={
-                                                this.props.currentTab
-                                                    .dropDownActive
-                                            }
                                             setDropDownStatus={
                                                 this.props.setDropDownStatus
                                             }
@@ -74,11 +70,7 @@ class SaveContainer extends Component {
                                             openOptions={this.props.openOptions}
                                             archive={this.props.archiveItem}
                                             remove={this.props.removeItem}
-                                            activeTab={this.props.currentTab}
-                                            type={this.props.currentTab.type}
-                                            status={
-                                                this.props.currentTab.status
-                                            }
+                                            currentTab={this.props.currentTab}
                                             active={this.props.active}
                                             tags={this.props.currentTags}
                                             activateTag={this.props.activateTag}
@@ -104,9 +96,6 @@ class SaveContainer extends Component {
                                         />
                                         {this.props.showRecs && (
                                             <Recommendations
-                                                hash={
-                                                    this.props.currentTab.hash
-                                                }
                                                 recs={this.props.currentRecs}
                                                 saveRecommendation={
                                                     this.props

--- a/src/containers/save/save.container.js
+++ b/src/containers/save/save.container.js
@@ -1,0 +1,128 @@
+import styles from './save.scss' // Import Styles
+import React, { Component } from 'react'
+//
+import Toolbar from './toolbar/toolbar.main'
+import Recommendations from './recommendations/recommendations.main'
+import { TransitionMotion, spring, presets } from 'react-motion' //
+
+class SaveContainer extends Component {
+    getDefaultStyles = () => {
+        return [
+            {
+                data: {},
+                key: 'toolbar',
+                style: {
+                    transform: -240,
+                    opacity: 0
+                }
+            }
+        ]
+    }
+
+    getStyles = () => {
+        return this.props.isSaveActive && this.props.currentTab
+            ? [
+                  {
+                      data: {},
+                      key: 'toolbar',
+                      style: {
+                          transform: spring(0, { stiffness: 250, damping: 25 }),
+                          opacity: spring(1, presets.stiff)
+                      }
+                  }
+              ]
+            : []
+    }
+
+    willEnter() {
+        return { transform: -240, opacity: 0 }
+    }
+    willLeave() {
+        return { transform: spring(-240), opacity: spring(0) }
+    }
+    render() {
+        return (
+            <TransitionMotion
+                defaultStyles={this.getDefaultStyles()}
+                styles={this.getStyles()}
+                willEnter={this.willEnter}
+                willLeave={this.willLeave}>
+                {items => {
+                    return (
+                        <div>
+                            {items.map(item => {
+                                return (
+                                    <div
+                                        className={styles.hanger}
+                                        key={item.key}
+                                        style={{
+                                            transform: `translateY(${
+                                                item.style.transform
+                                            }%) translateZ(0)`,
+                                            opacity: item.style.opacity
+                                        }}>
+                                        <Toolbar
+                                            tabId={this.props.tab_id}
+                                            dropDownActive={
+                                                this.props.currentTab
+                                                    .dropDownActive
+                                            }
+                                            setDropDownStatus={
+                                                this.props.setDropDownStatus
+                                            }
+                                            openPocket={this.props.openPocket}
+                                            openOptions={this.props.openOptions}
+                                            archive={this.props.archiveItem}
+                                            remove={this.props.removeItem}
+                                            activeTab={this.props.currentTab}
+                                            type={this.props.currentTab.type}
+                                            status={
+                                                this.props.currentTab.status
+                                            }
+                                            active={this.props.active}
+                                            tags={this.props.currentTags}
+                                            activateTag={this.props.activateTag}
+                                            deactivateTag={
+                                                this.props.deactivateTag
+                                            }
+                                            deactivateTags={
+                                                this.props.deactivateTags
+                                            }
+                                            addTag={this.props.addTag}
+                                            closePanel={this.props.closePanel}
+                                            removeTag={this.props.removeTag}
+                                            removeTags={this.props.removeTags}
+                                            storedTags={
+                                                this.props.setup.tags_stored
+                                            }
+                                            inputFocused={
+                                                this.props.inputFocused
+                                            }
+                                            setInputFocusState={
+                                                this.props.setInputFocusState
+                                            }
+                                        />
+                                        {this.props.showRecs && (
+                                            <Recommendations
+                                                hash={
+                                                    this.props.currentTab.hash
+                                                }
+                                                recs={this.props.currentRecs}
+                                                saveRecommendation={
+                                                    this.props
+                                                        .saveRecommendation
+                                                }
+                                            />
+                                        )}
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    )
+                }}
+            </TransitionMotion>
+        )
+    }
+}
+
+export default SaveContainer

--- a/src/containers/save/save.container.js
+++ b/src/containers/save/save.container.js
@@ -53,6 +53,8 @@ class SaveContainer extends Component {
                             {items.map(item => {
                                 return (
                                     <div
+                                        onMouseEnter={this.props.onHover}
+                                        onMouseLeave={this.props.offHover}
                                         className={styles.hanger}
                                         key={item.key}
                                         style={{

--- a/src/containers/save/save.container.js
+++ b/src/containers/save/save.container.js
@@ -26,7 +26,7 @@ class SaveContainer extends Component {
                       data: {},
                       key: 'toolbar',
                       style: {
-                          transform: spring(0, { stiffness: 250, damping: 25 }),
+                          transform: spring(0, { stiffness: 350, damping: 25 }),
                           opacity: spring(1, presets.stiff)
                       }
                   }
@@ -61,6 +61,7 @@ class SaveContainer extends Component {
                                             transform: `translateY(${
                                                 item.style.transform
                                             }%) translateZ(0)`,
+                                            transformStyle: 'preserve-3d',
                                             opacity: item.style.opacity
                                         }}>
                                         <Toolbar

--- a/src/containers/save/save.scss
+++ b/src/containers/save/save.scss
@@ -6,19 +6,9 @@
     @include fontBase;
 
     font-size: 16px;
-    opacity: 0;
     position: fixed;
     right: 10px;
     top: 15px;
-    transform: translateY(-240%);
-    transition: transform 400ms cubic-bezier(0.23, 1, 0.32, 1), opacity 400ms;
     width: 320px;
     z-index: 2147483647;
-
-    &.active,
-    &.saving,
-    &.saved {
-        opacity: 1;
-        transform: translateY(0);
-    }
 }

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -47,12 +47,8 @@ export const tags = (state = {}, action) => {
         }
 
         case 'TAB_CLOSED': {
-            const filteredState = Object.keys(state)
-                .filter(key => parseInt(key, 10) !== action.tabId)
-                .reduce((accumulator, key) => {
-                    accumulator[key] = state[key]
-                    return accumulator
-                }, {})
+            const filteredState = state
+            delete filteredState[action.tabId]
             return filteredState
         }
 

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -81,16 +81,16 @@ export const tags = (state = {}, action) => {
         }
 
         case 'TAG_REMOVE': {
+            const tabId = action.data.tabId
             const tag = action.data.tag
-            const usedTags = state[action.tabId].used.filter(
-                item => item !== tag
-            )
+            const activeTab = state[tabId]
+            const usedTags = activeTab ? activeTab.used : []
 
             return {
                 ...state,
-                [action.tabId]: {
-                    ...state[action.tabId],
-                    used: usedTags
+                [tabId]: {
+                    ...state[tabId],
+                    used: usedTags.filter(item => item !== tag)
                 }
             }
         }

--- a/src/containers/save/toolbar/tagging/suggestions/suggestions.js
+++ b/src/containers/save/toolbar/tagging/suggestions/suggestions.js
@@ -7,9 +7,12 @@ export default class Suggestions extends Component {
         event.preventDefault()
     }
 
+    get usedTags() {
+        return this.props.tags.used || []
+    }
     get listItems() {
         return this.props.suggestions
-            .filter(item => !this.props.tags.includes(item))
+            .filter(item => !this.usedTags.includes(item))
             .map((suggestion, index) => {
                 return (
                     <li
@@ -39,5 +42,5 @@ Suggestions.propTypes = {
     suggestions: PropTypes.array,
     addTag: PropTypes.func,
     value: PropTypes.string,
-    tags: PropTypes.array
+    tags: PropTypes.object
 }

--- a/src/containers/save/toolbar/tagging/tagging.js
+++ b/src/containers/save/toolbar/tagging/tagging.js
@@ -44,7 +44,7 @@ export default class Tagging extends Component {
     addTag = value => {
         if (value === '') return
         if (this.props.tags.used.indexOf(value) >= 0) return
-        this.props.addTag({ value, saveHash: this.props.saveHash })
+        this.props.addTag({ value, tabId: this.props.tabId })
         this.setState({ placeholder: false, inputvalue: '' })
         this.input.focus()
     }
@@ -52,26 +52,27 @@ export default class Tagging extends Component {
     /* Active/Inactive Tagging
     –––––––––––––––––––––––––––––––––––––––––––––––––– */
     makeTagActive = tag => {
-        return this.props.activateTag({ tag, saveHash: this.props.saveHash })
+        return this.props.activateTag({ tag, tabId: this.props.tabId })
     }
+
     makeTagInactive = tag => {
-        return this.props.deactivateTag({ tag, saveHash: this.props.saveHash })
+        return this.props.deactivateTag({ tag, tabId: this.props.tabId })
     }
 
     makeTagsInactive = blur => {
         if (!this.props.tags.marked.length)
             return blur ? this.input.blur() : null
-        this.props.deactivateTags({ saveHash: this.props.saveHash })
+        this.props.deactivateTags({ tabId: this.props.tabId })
     }
 
     handleRemoveAction = () => {
         if (this.state.inputvalue.length || !this.hasTags()) return
         if (!this.props.tags.marked.length) return this.makeTagActive()
-        this.props.removeTags({ saveHash: this.props.saveHash })
+        this.props.removeTags({ tabId: this.props.tabId })
     }
 
     removeTag = tag => {
-        this.props.removeTag({ tag, saveHash: this.props.saveHash })
+        this.props.removeTag({ tag, tabId: this.props.tabId })
     }
 
     toggleActive = (tag, active) => {
@@ -203,6 +204,5 @@ Tagging.propTypes = {
     activateTag: PropTypes.func,
     deactivateTags: PropTypes.func,
     addTag: PropTypes.func,
-    removeTags: PropTypes.func,
-    saveHash: PropTypes.string
+    removeTags: PropTypes.func
 }

--- a/src/containers/save/toolbar/tagging/tagging.js
+++ b/src/containers/save/toolbar/tagging/tagging.js
@@ -23,7 +23,8 @@ export default class Tagging extends Component {
 
     /* Utilities
     –––––––––––––––––––––––––––––––––––––––––––––––––– */
-    hasTags = () => this.props.tags && this.props.tags.used.length
+    hasTags = () =>
+        this.props.tags && this.props.tags.used && this.props.tags.used.length
 
     /* Input Management
     –––––––––––––––––––––––––––––––––––––––––––––––––– */
@@ -187,7 +188,7 @@ export default class Tagging extends Component {
                     this.props.tags.suggested && (
                         <Suggestions
                             value={this.state.inputvalue}
-                            tags={this.props.tags.used}
+                            tags={this.props.tags}
                             suggestions={this.props.tags.suggested}
                             addTag={this.addTag}
                             activate={this.activateTag}

--- a/src/containers/save/toolbar/toolbar.main.js
+++ b/src/containers/save/toolbar/toolbar.main.js
@@ -16,7 +16,10 @@ class Toolbar extends Component {
     archive = () => this.props.archive()
 
     get statusText() {
-        return getStatus(this.props.type, this.props.status)
+        const currentTab = this.props.currentTab
+        const type = currentTab ? currentTab.type : 'page'
+        const status = currentTab ? currentTab.status : 'idle'
+        return getStatus(type, status)
     }
 
     get listItems() {
@@ -46,7 +49,11 @@ class Toolbar extends Component {
     }
 
     render() {
-        const status = this.props.status
+        const currentTab = this.props.currentTab
+        const status = currentTab ? currentTab.status : 'idle'
+        const dropDownActive = this.props.currentTab
+            ? currentTab.dropDownActive
+            : false
 
         return (
             <div className={styles.toolbar}>
@@ -63,7 +70,7 @@ class Toolbar extends Component {
                     status !== 'error' && (
                         <Dropdown
                             tabId={this.props.tabId}
-                            active={this.props.dropDownActive}
+                            active={dropDownActive}
                             setStatus={this.props.setDropDownStatus}
                             list={this.listItems}
                         />

--- a/src/containers/save/toolbar/toolbar.main.js
+++ b/src/containers/save/toolbar/toolbar.main.js
@@ -47,7 +47,6 @@ class Toolbar extends Component {
 
     render() {
         const status = this.props.status
-        const saveHash = this.props.activeTab.hash
 
         return (
             <div className={styles.toolbar}>
@@ -80,7 +79,7 @@ class Toolbar extends Component {
                         closePanel={this.props.closePanel}
                         removeTag={this.props.removeTag}
                         removeTags={this.props.removeTags}
-                        saveHash={saveHash}
+                        tabId={this.props.tabId}
                         storedTags={this.props.storedTags}
                         inputFocused={this.props.inputFocused}
                         setInputFocusState={this.props.setInputFocusState}

--- a/src/store/combineSagas.js
+++ b/src/store/combineSagas.js
@@ -8,6 +8,8 @@ import { wToggleRecs } from '../containers/background/_setup'
 import { wToggleSite } from '../containers/background/_setup'
 import { wUserLoggedIn } from '../containers/background/_setup'
 
+import { wTabChanges } from '../containers/background/_tabs'
+
 import { wSaveTweet } from '../containers/background/_sites'
 
 import { wAuthCodeRecieved } from '../containers/auth/_auth'
@@ -40,6 +42,8 @@ export default function* rootSaga() {
         wToggleSite(),
         wSaveTweet(),
         wUserLoggedIn(),
+
+        wTabChanges(),
 
         wOpenPocket(),
         wOpenOptions(),


### PR DESCRIPTION
## Goal
Update the extension to resolve some performance issues.

## Todos:
- [x] Add check for system pages (chrome://extension) and avoid attempting to save them
- [x] Add Swap tabs functionality to avoid zombie tab references
- [x] Changed tab status caching so everything is keyed on the tab as opposed to the save hash.  This keeps the state cleaner.
- [x] Removed Save Hashing since we are not persisting saves
- [x] Fixed Zombie Tags on subsequent page saves
- [x] Fixed Zombie Recs on subsequent page saves
- [x] Fixed Tab messaging so frame updates are sent to active tab as opposed to all tabs (which was creating the slowdown with high volume tabs)

## Implementation Decisions

Prior to this release we were a bit more aggressive with caching and general readiness.  This approach was fine for low volume users but created some bottlenecks and slowdown as you got into higher volume tab usage.

This update fixes a lot of those underlying issues and changes the way we manage state on the backend.

This update addresses issues : https://github.com/Pocket/extension-save-to-pocket/issues/9 and https://github.com/Pocket/extension-save-to-pocket/issues/34 along with some additional optimizations and checks.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
