### PR TITLE
Fixing commented out panel closing

### DIFF
--- a/src/containers/save/_save.js
+++ b/src/containers/save/_save.js
@@ -99,8 +99,8 @@ function* closePanelRequest(action) {
 }
 
 function* closePanel(tabId, timeout) {
-    // yield call(delay, timeout)
-    // yield put({ type: 'SET_TAB_STATUS', tabId, status: 'idle', shown: false })
+    yield call(delay, timeout)
+    yield put({ type: 'SET_TAB_STATUS', tabId, status: 'idle', shown: false })
 }
 
 function* saveRequest(action) {


### PR DESCRIPTION
## Goal

Hot Fix to rectify come commented out code getting pushed live.  The close panel was not accessible. 

## Todos:
- [x] Un-Comment close panel code


## Implementation Decisions
This was commented out in order to better test some UI changes and it got left in accidentally. 

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
