### PR TITLE
WIP: Adding optional autoFocus tag entry on save

### DIFF
--- a/src/common/_locales/en/strings.json
+++ b/src/common/_locales/en/strings.json
@@ -48,6 +48,8 @@
         "quick_save_services_title" : "Quick save services:",
         "recommendations_detail": "When you save a page, see recommended stories from Pocket based on similar topics.",
         "recommendations_title": "Recommendations on Save",
+        "autofocus_detail": "When you save a page, auto-focus the tag entry field.",
+        "autofocus_title": "Auto-focus tagging",
         "record_shortcut" : "Record a new shortcut",
         "reset_to_default": "Reset to default",
         "save_to_pocket" : "Save To Pocket",

--- a/src/containers/background/_setup.js
+++ b/src/containers/background/_setup.js
@@ -12,6 +12,7 @@ const initialState = {
     base_installed: 1,
 
     on_save_recommendations: 1,
+    on_save_auto_focus: 0,
 
     sites_facebook: 1,
     sites_hackernews: 1,
@@ -23,6 +24,7 @@ const initialState = {
 export const setupActions = {
     setupExtension: () => ({ type: 'SETUP' }),
     toggleRecommendations: () => ({ type: 'TOGGLE_RECOMMENDATIONS' }),
+    toggleAutoFocus: () => ({ type: 'TOGGLE_AUTO_FOCUS' }),
     toggleKeyboardShortcut: () => ({ type: 'TOGGLE_SHORTCUT' }),
     toggleSite: sitename => ({ type: 'TOGGLE_SITE', sitename })
 }
@@ -61,6 +63,13 @@ export const setup = (state = initialState, action) => {
             }
         }
 
+        case 'SET_AUTO_FOCUS': {
+            return {
+                ...state,
+                on_save_auto_focus: action.active
+            }
+        }
+
         case 'SET_SITES': {
             return {
                 ...state,
@@ -90,6 +99,9 @@ export function* wHydrate() {
 }
 export function* wToggleRecs() {
     yield takeLatest('TOGGLE_RECOMMENDATIONS', toggleRecommendations)
+}
+export function* wToggleAutoFocus() {
+    yield takeLatest('TOGGLE_AUTO_FOCUS', toggleAutoFocus)
 }
 export function* wToggleSite() {
     yield takeLatest('TOGGLE_SITE', toggleSite)
@@ -131,6 +143,7 @@ function* hydrateState() {
         account_avatar: getSetting('account_avatar'),
         account_premium: getBool(getSetting('account_premium')),
         on_save_recommendations: getBool(getSetting('on_save_recommendations')),
+        on_save_auto_focus: getBool(getSetting('on_save_auto_focus')),
         sites_facebook: getBool(getSetting('sites_facebook')),
         sites_hackernews: getBool(getSetting('sites_hackernews')),
         sites_reddit: getBool(getSetting('sites_reddit')),
@@ -147,6 +160,14 @@ function* toggleRecommendations() {
 
     setSettings({ on_save_recommendations: active ? 0 : 1 })
     yield put({ type: 'SET_RECOMMENDATIONS', active: !active })
+}
+
+function* toggleAutoFocus() {
+    const setup = yield select(getSetup)
+    const active = setup.on_save_auto_focus
+
+    setSettings({ on_save_auto_focus: active ? 0 : 1 })
+    yield put({ type: 'SET_AUTO_FOCUS', active: !active })
 }
 
 function* toggleSite(action) {

--- a/src/containers/options/options.app.js
+++ b/src/containers/options/options.app.js
@@ -142,6 +142,28 @@ export default class Options extends Component {
                 <div className={styles.section}>
                     <div className={styles.sectionContent}>
                         <div className={styles.sectionTitle}>
+                            {localize('options_page', 'autofocus_title')}
+                        </div>
+                        <div className={styles.sectionMain}>
+                            <Toggle
+                                active={
+                                    this.props.setup.on_save_auto_focus
+                                }
+                                action={this.props.toggleAutoFocus}
+                            />
+                            <div className={styles.info}>
+                                {localize(
+                                    'options_page',
+                                    'autofocus_detail'
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className={styles.section}>
+                    <div className={styles.sectionContent}>
+                        <div className={styles.sectionTitle}>
                             {localize('options_page', 'questions_pocket_title')}
                         </div>
                         <div className={styles.sectionMain}>

--- a/src/containers/save/save.app.js
+++ b/src/containers/save/save.app.js
@@ -20,7 +20,7 @@ class App extends Component {
         }
     }
 
-    componentWillUpdate(nextProps, nextState) {
+    componentWillUpdate(nextProps) {
         const isActive = nextProps.tab_id === nextProps.active
         const currentTab = nextProps.tabs
             ? nextProps.tabs[nextProps.active]
@@ -110,6 +110,7 @@ class App extends Component {
                 <SaveContainer
                     isSaveActive={this.isSaveActive()}
                     showRecs={this.showRecs}
+                    shouldAutoFocus={this.props.setup.on_save_auto_focus}
                     onHover={this.onHover}
                     offHover={this.offHover}
                     tab_id={this.props.tab_id}

--- a/src/containers/save/save.container.js
+++ b/src/containers/save/save.container.js
@@ -66,6 +66,7 @@ class SaveContainer extends Component {
                                         }}>
                                         <Toolbar
                                             tabId={this.props.tab_id}
+                                            shouldAutoFocus={this.props.shouldAutoFocus}
                                             setDropDownStatus={
                                                 this.props.setDropDownStatus
                                             }

--- a/src/containers/save/toolbar/tagging/tagging.js
+++ b/src/containers/save/toolbar/tagging/tagging.js
@@ -139,6 +139,7 @@ export default class Tagging extends Component {
                                 )}
 
                                 <Taginput
+                                    shouldAutoFocus={this.props.shouldAutoFocus}
                                     highlightedIndex={highlightedIndex}
                                     getInputProps={getInputProps}
                                     hasTags={!!this.hasTags()}

--- a/src/containers/save/toolbar/tagging/taginput/taginput.js
+++ b/src/containers/save/toolbar/tagging/taginput/taginput.js
@@ -110,7 +110,8 @@ export default class Taginput extends Component {
                         onBlur: this.props.setBlur,
                         onKeyUp: this.onKeyUp,
                         onKeyDown: this.onInput,
-                        onKeyPress: this.onInput
+                        onKeyPress: this.onInput,
+                        autoFocus: this.props.shouldAutoFocus
                     })}
                 />
                 {this.state.error && (

--- a/src/containers/save/toolbar/toolbar.main.js
+++ b/src/containers/save/toolbar/toolbar.main.js
@@ -78,6 +78,7 @@ class Toolbar extends Component {
 
                 {(status === 'saved' || status === 'saving') && (
                     <Tagging
+                        shouldAutoFocus={this.props.shouldAutoFocus}
                         tags={this.props.tags}
                         activateTag={this.props.activateTag}
                         deactivateTag={this.props.deactivateTag}

--- a/src/store/combineActions.js
+++ b/src/store/combineActions.js
@@ -4,7 +4,7 @@ import { saveActions } from '../containers/save/_save'
 import { taggingActions } from '../containers/save/toolbar/tagging/_tagging'
 import { recommendationActions } from '../containers/save/recommendations/_recommendations'
 
-const { setupExtension, toggleRecommendations, toggleSite } = setupActions
+const { setupExtension, toggleRecommendations, toggleAutoFocus, toggleSite } = setupActions
 
 const { frameLoaded, setTabStatus, setDropDownStatus } = tabsActions
 
@@ -39,6 +39,7 @@ const {
 export {
     setupExtension,
     toggleRecommendations,
+    toggleAutoFocus,
     toggleSite,
     frameLoaded,
     setTabStatus,

--- a/src/store/combineSagas.js
+++ b/src/store/combineSagas.js
@@ -5,6 +5,7 @@ import { openOptions } from '../common/interface'
 import { wSetup } from '../containers/background/_setup'
 import { wHydrate } from '../containers/background/_setup'
 import { wToggleRecs } from '../containers/background/_setup'
+import { wToggleAutoFocus } from '../containers/background/_setup'
 import { wToggleSite } from '../containers/background/_setup'
 import { wUserLoggedIn } from '../containers/background/_setup'
 
@@ -44,6 +45,7 @@ export default function* rootSaga() {
         wSetup(),
         wHydrate(),
         wToggleRecs(),
+        wToggleAutoFocus(),
         wToggleSite(),
         wSaveTweet(),
         wUserLoggedIn(),


### PR DESCRIPTION
## Goal

This updates allows user to opt in to the tag field auto-focusing on save.

## Todos:
- [ ] Finalize copy and localization 
- [x] Add Option to toggle auto-focus tagging on save
- [x] Functionality for auto-focus on save

## Implementation Decisions
Since not all users leverage tags, this feature will be optional.  It is off by default. We should consider adding some release notes to surface this functionality.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
