### PR TITLE
Fix Fallback Reccomendation URL

### DIFF
--- a/src/containers/save/recommendations/_recommendations.js
+++ b/src/containers/save/recommendations/_recommendations.js
@@ -25,7 +25,7 @@ function buildFeed(feed, source_id) {
             title: rec.item.title,
             resolved_url: rec.item.resolved_url,
             display_url: rec.item.resolved_url,
-            url: rec.item.given_url,
+            url: rec.item.given_url || rec.item.resolved_url,
             excerpt: rec.item.excerpt,
             image: getBestImage(rec.item),
             status: 'idle'

--- a/src/containers/save/recommendations/list/item.js
+++ b/src/containers/save/recommendations/list/item.js
@@ -120,7 +120,7 @@ export default class RecommendationItem extends Component {
                                     tabId: this.props.tabId,
                                     item_id: item.id.toString(),
                                     title: item.title,
-                                    url: item.url || item.resolved_url,
+                                    url: item.url,
                                     position: this.props.position,
                                     source_id: item.source_id
                                 })


### PR DESCRIPTION
## Goal

This keeps falling out with combined merges... so this is a dedicated PR just for this specific fix.

For the record: We favor `given_url` and are falling back to `resolved_url` when building the feed.  

## Todos:
- [x] Favor given_url and fallback to resolve_url when building the feed.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
