### PR TITLE
increase timer modal to match current version

### DIFF
--- a/src/Containers/Save/save.state.js
+++ b/src/Containers/Save/save.state.js
@@ -206,7 +206,7 @@ function* removeItemRequest(action) {
 
 // Idle Timer
 // TODO: Account for user entering the area before animation is complete
-function* startIdleTimer(action, timeout = 3000) {
+function* startIdleTimer(action, timeout = 6000) {
   const tabId = yield select(getActiveTabId)
   yield race({
     task: call(idleTimer, tabId, timeout),


### PR DESCRIPTION
## Goal

The goal is to improve UX by matching the same timeout as the v3.0.5.
Fix https://getpocket.atlassian.net/browse/P19-511

## Todos:
- [x] Measure time used by current modal ~6 seconds
- [x] Update timeout to match

## Implementation Decisions


## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
