### PR TITLE
feat(safari): add authenticate user

### DIFF
--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -6,107 +6,142 @@
 //  Copyright © 2019 Pocket. All rights reserved.
 //
 
-  // ✅ SUPPORT THESE FOR MVP
-  // ---------------------------------------
-  // authorize
-  // getGuid
+// ✅ SUPPORT THESE FOR MVP
+// ---------------------------------------
+// authorize
+// getGuid
 
-  // saveToPocket
-  // getOnSaveTags
+// saveToPocket
+// getOnSaveTags
 
-  // syncItemTags
-  // fetchStoredTags
+// syncItemTags
+// fetchStoredTags
 
-  // archiveItem
-  // removeItem
+// archiveItem
+// removeItem
 
-  // sendAnalytics
+// sendAnalytics
 
-  // 🙈 FAST FOLLOW WITH THESE
-  // ---------------------------------------
-  // getFeatures
+// 🙈 FAST FOLLOW WITH THESE
+// ---------------------------------------
+// getFeatures
 
-  // getRecommendations
-  // saveRecToPocket
-  // openRecommendation
+// getRecommendations
+// saveRecToPocket
+// openRecommendation
 
-  // sendSurvey
-  // sendSurveyAnalytics
+// sendSurvey
+// sendSurveyAnalytics
 
 import SafariServices
 
 class SaveToPocketAPI: SafariExtensionHandler{
-
-  static func getGuid(from page: SFSafariPage) -> String {
+  
+  static func getGuid(from page: SFSafariPage, completion: @escaping (Result<String, RequestError>) -> Void) -> Void {
     // Get authorized from server
     // Build request data dictionary
     let requestData: [String : Any] = [
       "consumer_key": "70018-b83d4728573df682a7c50b3d",
       "abt": "1"
     ]
-
+    
     let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/guid/",
                                        "method" : "GET",
                                        "parameters" : requestData
     ];
-
+    
     NSLog("Request Guid: (\(String(describing: requestInfo)))")
-    do{
-      let data = try Utilities.request(from: page, userInfo: requestInfo)
-      let guidJSON = try JSONDecoder().decode(GuidResponse.self, from: data!)
-      return guidJSON.guid
-    } catch {
-      NSLog("Request Failed: (\(String(describing: requestInfo)))")
-      return "This is not my guid"
+    Utilities.request(from: page, userInfo: requestInfo) { result in
+      switch result {
+      case .success(let data):
+        guard let guidJSON = try? JSONDecoder().decode(GuidResponse.self, from: data) else {
+          completion(.failure(.json))
+          return
+        }
+        completion(.success(guidJSON.guid))
+      case .failure(let error):
+        NSLog("Request Failed: (\(String(describing: requestInfo)))")
+        completion(.failure(error))
+      }
     }
   }
-
-  static func validateAuthCode(from page: SFSafariPage, userInfo: [String : Any]?) -> Void {
-
+  
+  static func validateAuthCode(from page: SFSafariPage, userInfo: [String : Any]?, completion: @escaping (Result<String, RequestError>) -> Void) -> Void {
+    
     // Since we got the Auth Code from the passed in page, we close that page
     Utilities.closeTab(from: page, userInfo: userInfo)
-
+    
     guard let userId = userInfo!["userId"] as? String, let token = userInfo!["token"] as? String  else {
       NSLog("Auth Tokens Missing: \(String(describing: userInfo))")
       return
     }
     NSLog("User ID: (\(String(describing: userId))) - Token: (\(String(describing: token))")
-
-    let guid = self.getGuid(from: page)
-    NSLog("GUID: \(String(describing: guid))")
-
-    // Get authorized from server
-    // Build request data dictionary
-    let requestData: [String : Any] = [
-      "consumer_key": "70018-b83d4728573df682a7c50b3d",
-      "guid": guid,
-      "token": token,
-      "user_id" : userId,
-      "account": "1",
-      "grant_type": "extension"
-    ]
-
-    let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/oauth/authorize.php",
-                                       "method" : "POST",
-                                       "parameters" : requestData
-    ];
-
-
-    NSLog("Auth Request: (\(String(describing: requestInfo)))")
-    do{
-      guard let data = try Utilities.request(from: page, userInfo: requestInfo) else {
-        throw RequestErrors.auth
+    
+    // Create a serial queue.
+    let queue = DispatchQueue(label: "API.validateAuthCode")
+    
+    // Run all requests within queue.
+    queue.async {
+      
+      var guid: String? = nil
+      var error: RequestError = .undefined
+      
+      let waitOnGuid = DispatchSemaphore(value: 0)
+      
+      getGuid(from: page) { result in
+        switch result {
+        case .failure(let e):
+          error = e
+        case .success(let g):
+          guid = g
+          NSLog("GUID: \(String(describing: guid))")
+          // Signal semaphore to unblock this queue.
+          waitOnGuid.signal()
+        }
       }
-
-      let authJSON = try JSONDecoder().decode(AuthResponse.self, from: data)
-
-      // Store Account data
-      let defaults = UserDefaults.standard
-      defaults.set(authJSON.access_token, forKey: "access_token")
-
-    } catch {
-      NSLog("Auth Failed: (\(String(describing: requestInfo)))")
+      
+      // We can block this queue without affecting the main thread.
+      _ = waitOnGuid.wait(timeout: .distantFuture)
+      
+      guard guid != nil else {
+        completion(.failure(error))
+        return
+      }
+      
+      // Get authorized from server
+      // Build request data dictionary
+      let requestData: [String : Any] = [
+        "consumer_key": "70018-b83d4728573df682a7c50b3d",
+        "guid": guid as Any,
+        "token": token,
+        "user_id" : userId,
+        "account": "1",
+        "grant_type": "extension"
+      ]
+      
+      
+      let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/oauth/authorize.php",
+                                         "method" : "POST",
+                                         "parameters" : requestData
+      ];
+      
+      NSLog("Auth Request: (\(String(describing: requestInfo)))")
+      Utilities.request(from: page, userInfo: requestInfo) { result in
+        switch result {
+        case .failure(_):
+          NSLog("Auth Failed: (\(String(describing: requestInfo)))")
+        case .success(let data):
+          guard let authJSON = try? JSONDecoder().decode(AuthResponse.self, from: data) else {
+            NSLog("Auth Failed: (\(String(describing: requestInfo)))")
+            completion(.failure(.auth))
+            return
+          }
+          // Store Account data
+          let defaults = UserDefaults.standard
+          defaults.set(authJSON.access_token, forKey: "access_token")
+          completion(.success(authJSON.access_token))
+        }
+      }
     }
   }
-
 }

--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -1,0 +1,112 @@
+//
+//  API.swift
+//  Save to Pocket Extension
+//
+//  Created by Joel Kelly on 8/19/19.
+//  Copyright © 2019 Pocket. All rights reserved.
+//
+
+  // ✅ SUPPORT THESE FOR MVP
+  // ---------------------------------------
+  // authorize
+  // getGuid
+
+  // saveToPocket
+  // getOnSaveTags
+
+  // syncItemTags
+  // fetchStoredTags
+
+  // archiveItem
+  // removeItem
+
+  // sendAnalytics
+
+  // 🙈 FAST FOLLOW WITH THESE
+  // ---------------------------------------
+  // getFeatures
+
+  // getRecommendations
+  // saveRecToPocket
+  // openRecommendation
+
+  // sendSurvey
+  // sendSurveyAnalytics
+
+import SafariServices
+
+class SaveToPocketAPI: SafariExtensionHandler{
+
+  static func getGuid(from page: SFSafariPage) -> String {
+    // Get authorized from server
+    // Build request data dictionary
+    let requestData: [String : Any] = [
+      "consumer_key": "70018-b83d4728573df682a7c50b3d",
+      "abt": "1"
+    ]
+
+    let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/guid/",
+                                       "method" : "GET",
+                                       "parameters" : requestData
+    ];
+
+    NSLog("Request Guid: (\(String(describing: requestInfo)))")
+    do{
+      let data = try Utilities.request(from: page, userInfo: requestInfo)
+      let guidJSON = try JSONDecoder().decode(GuidResponse.self, from: data!)
+      return guidJSON.guid
+    } catch {
+      NSLog("Request Failed: (\(String(describing: requestInfo)))")
+      return "This is not my guid"
+    }
+  }
+
+  static func validateAuthCode(from page: SFSafariPage, userInfo: [String : Any]?) -> Void {
+
+    // Since we got the Auth Code from the passed in page, we close that page
+    Utilities.closeTab(from: page, userInfo: userInfo)
+
+    guard let userId = userInfo!["userId"] as? String, let token = userInfo!["token"] as? String  else {
+      NSLog("Auth Tokens Missing: \(String(describing: userInfo))")
+      return
+    }
+    NSLog("User ID: (\(String(describing: userId))) - Token: (\(String(describing: token))")
+
+    let guid = self.getGuid(from: page)
+    NSLog("GUID: \(String(describing: guid))")
+
+    // Get authorized from server
+    // Build request data dictionary
+    let requestData: [String : Any] = [
+      "consumer_key": "70018-b83d4728573df682a7c50b3d",
+      "guid": guid,
+      "token": token,
+      "user_id" : userId,
+      "account": "1",
+      "grant_type": "extension"
+    ]
+
+    let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/oauth/authorize.php",
+                                       "method" : "POST",
+                                       "parameters" : requestData
+    ];
+
+
+    NSLog("Auth Request: (\(String(describing: requestInfo)))")
+    do{
+      guard let data = try Utilities.request(from: page, userInfo: requestInfo) else {
+        throw RequestErrors.auth
+      }
+
+      let authJSON = try JSONDecoder().decode(AuthResponse.self, from: data)
+
+      // Store Account data
+      let defaults = UserDefaults.standard
+      defaults.set(authJSON.access_token, forKey: "access_token")
+
+    } catch {
+      NSLog("Auth Failed: (\(String(describing: requestInfo)))")
+    }
+  }
+
+}

--- a/_safari/Save to Pocket Extension/Common/Structures.swift
+++ b/_safari/Save to Pocket Extension/Common/Structures.swift
@@ -1,0 +1,36 @@
+//
+//  SaveToPocket.structures.swift
+//  Save to Pocket Extension
+//
+//  Created by Joel Kelly on 8/19/19.
+//  Copyright © 2019 Pocket. All rights reserved.
+//
+
+struct GuidResponse: Decodable {
+  let guid: String
+}
+//
+struct AuthResponse: Decodable{
+  let access_token: String
+  let username: String?
+  let account: Account?
+}
+
+struct Account: Decodable{
+  let user_id: String
+  let username: String?
+  let email: String?
+  let birth: String?
+  let first_name: String?
+  let last_name: String?
+  let premium_status: String?
+  let profile: Profile?
+}
+
+struct Profile: Decodable{
+  let username: String?
+  let name: String?
+  let description: String?
+  let avatar_url: String?
+}
+

--- a/_safari/Save to Pocket Extension/Common/Utilities.swift
+++ b/_safari/Save to Pocket Extension/Common/Utilities.swift
@@ -1,0 +1,35 @@
+//
+//  SaveToPocketUtilities.swift
+//  Save to Pocket Extension
+//
+//  Created by Joel Kelly on 8/17/19.
+//  Copyright © 2019 Pocket. All rights reserved.
+//
+
+import SafariServices
+
+class Utilities: SafariExtensionHandler {
+  
+  static func closeTab(from page: SFSafariPage, userInfo: [String : Any]?) {
+    page.getContainingTab { (tab) in
+      tab.close()
+    }
+  }
+  
+  static func openBackgroundTab(from page: SFSafariPage, userInfo: [String : Any]?) {
+    guard let uri: String = userInfo?["url"] as? String, let url = URL(string: uri) else {
+      NSLog("Invalid URI: \(String(describing: userInfo))")
+      return
+    }
+    page.getContainingTab { (tab) in
+      tab.getContainingWindow(completionHandler: { (window) in
+        window?.openTab(with: url, makeActiveIfPossible: true, completionHandler: { (tab) in
+          if tab != nil {
+            NSLog("opened tab")
+          }
+        })
+      })
+    }
+  }
+  
+}

--- a/_safari/Save to Pocket Extension/Common/Utilities.swift
+++ b/_safari/Save to Pocket Extension/Common/Utilities.swift
@@ -65,6 +65,7 @@ class Utilities {
           // Once we get the response, check that it's valid?
           if let restResponse = response as? HTTPURLResponse, restResponse.statusCode > 300 {
             completion(.failure(.statusCode))
+            return
           }
           guard let responseData = data else {
             completion(.failure(.error))

--- a/_safari/Save to Pocket Extension/Common/Utilities.swift
+++ b/_safari/Save to Pocket Extension/Common/Utilities.swift
@@ -31,5 +31,57 @@ class Utilities: SafariExtensionHandler {
       })
     }
   }
-  
+
+  static func request(from page: SFSafariPage, userInfo: [String : Any]?) throws -> Data? {
+    guard let uri: String = userInfo?["url"] as? String, let url = URL(string: uri) else {
+      throw RequestErrors.url
+    }
+    
+    // Semaphor gives us the ability to emulate async/await
+    let semaphore = DispatchSemaphore(value: 0)
+    
+    // Construct the URLRequest
+    var urlRequest = URLRequest(url: url)
+    urlRequest.httpMethod = "POST"
+    
+    // Add request parameters
+    if let parameters = userInfo?["parameters"] as? [ String : Any],
+      JSONSerialization.isValidJSONObject(parameters),
+      let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: .prettyPrinted) {
+      urlRequest.httpBody = jsonData
+      urlRequest.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+      urlRequest.setValue("application/json", forHTTPHeaderField: "X-Accept")
+    }
+    
+    // Variables to hold response
+    var data: Data?
+    var response: URLResponse?
+    var error: Error?
+    
+    // Make the request and capure the response
+    _ = URLSession.shared.dataTask(with: urlRequest){ rData, rResponse, rError in
+      data = rData
+      response = rResponse
+      error = rError
+      semaphore.signal()
+      }.resume()
+    
+    // Pause execution until we get the signal from the semaphore
+    _ = semaphore.wait(timeout: .distantFuture)
+    
+    // Once we get the response, check that it's valid?
+    if let restResponse = response as? HTTPURLResponse, restResponse.statusCode > 300 {
+      throw RequestErrors.statusCode
+    }
+    
+    // Are there any errors?
+    if error != nil {
+      throw RequestErrors.error
+    }
+    
+    // Excellent—Pass on the data
+    let string = String(data: data!, encoding: String.Encoding.utf8)
+    NSLog("Auth Success (string): (\(String(describing: string!)))")
+    return data
+  }
 }

--- a/_safari/Save to Pocket Extension/Info.plist
+++ b/_safari/Save to Pocket Extension/Info.plist
@@ -36,6 +36,14 @@
 				<key>Script</key>
 				<string>script.js</string>
 			</dict>
+			<dict>
+				<key>Script</key>
+				<string>login.js</string>
+				<key>Allowed URL Patterns</key>
+				<array>
+					<string>https://getpocket.com/extension_login_success</string>
+				</array>
+			</dict>
 		</array>
 		<key>SFSafariContextMenu</key>
 		<array>

--- a/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
+++ b/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
@@ -8,11 +8,14 @@
 
 import SafariServices
 
-enum RequestErrors: Error {
+enum RequestError: Error {
+  case undefined
   case auth
   case url
   case statusCode
   case error
+  /// Received invalid or unexpected JSON response data
+  case json
 }
 
 class SafariExtensionHandler: SFSafariExtensionHandler {
@@ -29,7 +32,14 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
       NSLog("Main Script Injected")
     
     case "AUTH_CODE_RECEIVED":
-      SaveToPocketAPI.validateAuthCode(from: page, userInfo: userInfo)
+      SaveToPocketAPI.validateAuthCode(from: page, userInfo: userInfo) { result in
+        switch result {
+        case .success(_):
+          NSLog("Auth code validated")
+        case .failure(let error):
+          NSLog("Failed to validate auth code: \(error)")
+        }
+      }
       
     default:
       page.getPropertiesWithCompletionHandler { properties in

--- a/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
+++ b/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
@@ -29,7 +29,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
       NSLog("Main Script Injected")
     
     case "AUTH_CODE_RECEIVED":
-      NSLog("Authentication Token Received")
+      SaveToPocketAPI.validateAuthCode(from: page, userInfo: userInfo)
       
     default:
       page.getPropertiesWithCompletionHandler { properties in

--- a/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
+++ b/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
@@ -24,9 +24,13 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     NSLog("Message received: \(messageName), with userInfo: \(String(describing: userInfo))")
 
     switch messageName {
+    
     case "MAIN_SCRIPT_INJECTED":
       NSLog("Main Script Injected")
-
+    
+    case "AUTH_CODE_RECEIVED":
+      NSLog("Authentication Token Received")
+      
     default:
       page.getPropertiesWithCompletionHandler { properties in
         NSLog("""
@@ -53,9 +57,29 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 
   override func toolbarItemClicked(in window: SFSafariWindow) {
     // This method will be called when your toolbar item is clicked.
-
     NSLog("The extension's toolbar item was clicked.")
 
+    // Open Auth Page
+    window.getActiveTab { (tab) in
+      tab?.getActivePage(completionHandler: { (page) in
+        
+        // Grab our stored values
+        let defaults = UserDefaults.standard
+        
+        // Do we have an auth token?
+        guard let access_token = defaults.string(forKey: "access_token") else {
+          
+          // No auth token, so let's get one
+          Utilities.openBackgroundTab(from: page!,
+                                      userInfo: ["url" : "https://getpocket.com/signup?src=extension&route=/extension_login_success"])
+          return
+        }
+        
+        
+        // Hey AuthToken exists! Save the page
+        // MAKE CALL TO SAVE
+      })
+    }
   }
 
 }

--- a/_safari/Save to Pocket Extension/login.js
+++ b/_safari/Save to Pocket Extension/login.js
@@ -1,0 +1,36 @@
+/*global safari*/
+
+// Check page has loaded and if not add listener for it
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setLoginLoaded)
+} else {
+  setLoginLoaded()
+}
+
+function setLoginLoaded() {
+  const siteCookies = getCookies(document.cookie)
+  const loginMessage = {
+    userId: siteCookies['sess_user_id'],
+    token: siteCookies['sess_exttok']
+  }
+
+  setTimeout(function() {
+    safari.extension.dispatchMessage('AUTH_CODE_RECEIVED', { ...loginMessage })
+  }, 1000)
+}
+
+/* UTILITIES
+–––––––––––––––––––––––––––––––––––––––––––––––––– */
+function getCookies(cookieString) {
+  if (!cookieString || cookieString === '') return {}
+  return cookieString
+    .split(';')
+    .map(x => x.trim().split(/(=)/))
+    .reduce(
+      (cookiesObject, currentArray) => ({
+        ...cookiesObject,
+        [currentArray[0]]: decodeURIComponent(currentArray[2])
+      }),
+      {}
+    )
+}


### PR DESCRIPTION
## Goal

Add authentication of the Safari App Extension

## Todos:
- [x] Inject script into `extension_login_success` page
- [x] Gather extension tokens from cookies
- [x] Pass extension tokens to Safari App Extension 
- [x] Get GUID
- [x] Authenticate extension token through API
- [x] Store authentication tokens

## Implementation Decisions
I have broken out the files into API, Utilities, Structure to keep the logic separate from the dispatcher.  This should allow people less familiar with Swift to interface with the extension handler without getting bogged down.

## Notes
This branch will be rebased once the PR #104 is completed, so that should be reviewed first.
