### PR TITLE
feat(safari): add save to pocket

### DIFF
--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -191,6 +191,8 @@ class SaveToPocketAPI: SafariExtensionHandler{
 
       case .failure(_):
         NSLog("Save Failed: (\(String(describing: requestInfo)))")
+        completion(.failure(error))
+        return
 
       case .success(let data):
         guard let saveJSON = try? JSONDecoder().decode(AddResponse.self, from: data) else {

--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -36,36 +36,43 @@
 import SafariServices
 
 class SaveToPocketAPI: SafariExtensionHandler{
-  
-  static func getGuid(from page: SFSafariPage, completion: @escaping (Result<String, RequestError>) -> Void) -> Void {
-    // Get authorized from server
+
+  static func getGuid(
+    from page: SFSafariPage,
+    completion: @escaping (Result<String, RequestError>) -> Void
+  ) -> Void {
+
     // Build request data dictionary
     let requestData: [String : Any] = [
       "consumer_key": "70018-b83d4728573df682a7c50b3d",
       "abt": "1"
     ]
-    
-    let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/guid/",
-                                       "method" : "GET",
-                                       "parameters" : requestData
+
+    let requestInfo: [String : Any] = [
+      "url" : "https://getpocket.com/v3/guid/",
+      "method" : "GET",
+      "parameters" : requestData
     ];
-    
+
     NSLog("Request Guid: (\(String(describing: requestInfo)))")
+
     Utilities.request(from: page, userInfo: requestInfo) { result in
       switch result {
+
       case .success(let data):
         guard let guidJSON = try? JSONDecoder().decode(GuidResponse.self, from: data) else {
           completion(.failure(.json))
           return
         }
         completion(.success(guidJSON.guid))
+
       case .failure(let error):
         NSLog("Request Failed: (\(String(describing: requestInfo)))")
         completion(.failure(error))
       }
     }
   }
-  
+
   static func validateAuthCode(from page: SFSafariPage, userInfo: [String : Any]?, completion: @escaping (Result<String, RequestError>) -> Void) -> Void {
     
     // Since we got the Auth Code from the passed in page, we close that page
@@ -79,19 +86,21 @@ class SaveToPocketAPI: SafariExtensionHandler{
     
     // Create a serial queue.
     let queue = DispatchQueue(label: "API.validateAuthCode")
-    
+
     // Run all requests within queue.
     queue.async {
-      
+
       var guid: String? = nil
       var error: RequestError = .undefined
-      
+
       let waitOnGuid = DispatchSemaphore(value: 0)
-      
+
       getGuid(from: page) { result in
         switch result {
+
         case .failure(let e):
           error = e
+
         case .success(let g):
           guid = g
           NSLog("GUID: \(String(describing: guid))")
@@ -99,15 +108,15 @@ class SaveToPocketAPI: SafariExtensionHandler{
           waitOnGuid.signal()
         }
       }
-      
+
       // We can block this queue without affecting the main thread.
       _ = waitOnGuid.wait(timeout: .distantFuture)
-      
+
       guard guid != nil else {
         completion(.failure(error))
         return
       }
-      
+
       // Get authorized from server
       // Build request data dictionary
       let requestData: [String : Any] = [
@@ -118,27 +127,33 @@ class SaveToPocketAPI: SafariExtensionHandler{
         "account": "1",
         "grant_type": "extension"
       ]
-      
-      
-      let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/oauth/authorize.php",
-                                         "method" : "POST",
-                                         "parameters" : requestData
+
+
+      let requestInfo: [String : Any] = [
+        "url" : "https://getpocket.com/v3/oauth/authorize.php",
+        "method" : "POST",
+        "parameters" : requestData
       ];
-      
-      NSLog("Auth Request: (\(String(describing: requestInfo)))")
+
+      //
+      NSLog("Request Auth: (\(String(describing: requestInfo)))")
       Utilities.request(from: page, userInfo: requestInfo) { result in
         switch result {
+
         case .failure(_):
           NSLog("Auth Failed: (\(String(describing: requestInfo)))")
+
         case .success(let data):
           guard let authJSON = try? JSONDecoder().decode(AuthResponse.self, from: data) else {
             NSLog("Auth Failed: (\(String(describing: requestInfo)))")
             completion(.failure(.auth))
             return
           }
+
           // Store Account data
           let defaults = UserDefaults.standard
           defaults.set(authJSON.access_token, forKey: "access_token")
+
           completion(.success(authJSON.access_token))
         }
       }

--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -74,10 +74,6 @@ class SaveToPocketAPI: SafariExtensionHandler{
   }
 
   static func validateAuthCode(from page: SFSafariPage, userInfo: [String : Any]?, completion: @escaping (Result<String, RequestError>) -> Void) -> Void {
-    
-    // Since we got the Auth Code from the passed in page, we close that page
-    Utilities.closeTab(from: page, userInfo: userInfo)
-    
     guard let userId = userInfo!["userId"] as? String, let token = userInfo!["token"] as? String  else {
       NSLog("Auth Tokens Missing: \(String(describing: userInfo))")
       return

--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -74,12 +74,13 @@ class SaveToPocketAPI: SafariExtensionHandler{
   }
 
   static func validateAuthCode(from page: SFSafariPage, userInfo: [String : Any]?, completion: @escaping (Result<String, RequestError>) -> Void) -> Void {
+
+    // Check that tokens were properly returned
     guard let userId = userInfo!["userId"] as? String, let token = userInfo!["token"] as? String  else {
       NSLog("Auth Tokens Missing: \(String(describing: userInfo))")
       return
     }
-    NSLog("User ID: (\(String(describing: userId))) - Token: (\(String(describing: token))")
-    
+
     // Create a serial queue.
     let queue = DispatchQueue(label: "API.validateAuthCode")
 
@@ -99,7 +100,7 @@ class SaveToPocketAPI: SafariExtensionHandler{
 
         case .success(let g):
           guid = g
-          NSLog("GUID: \(String(describing: guid))")
+
           // Signal semaphore to unblock this queue.
           waitOnGuid.signal()
         }
@@ -151,8 +152,65 @@ class SaveToPocketAPI: SafariExtensionHandler{
           defaults.set(authJSON.access_token, forKey: "access_token")
 
           completion(.success(authJSON.access_token))
+
         }
       }
     }
   }
+
+  static func saveToPocket(
+    from page: SFSafariPage,
+    url: String,
+    access_token: String,
+    completion: @escaping (Result<Any, RequestError>) -> Void
+    ) -> Void {
+
+
+    // Build Action
+    let saveAction: [String : Any] = [
+      "action": "add",
+      "url": url
+    ]
+
+    // Build request data dictionary
+    let requestData: [String : Any] = [
+      "consumer_key": "70018-b83d4728573df682a7c50b3d",
+      "access_token": access_token,
+      "actions": [saveAction]
+    ]
+
+
+    let requestInfo: [String : Any] = [
+      "url" : "https://getpocket.com/v3/send/",
+      "method" : "POST",
+      "parameters" : requestData
+    ];
+
+    Utilities.request(from: page, userInfo: requestInfo) { result in
+      switch result {
+
+      case .failure(_):
+        NSLog("Save Failed: (\(String(describing: requestInfo)))")
+
+      case .success(let data):
+        guard let saveJSON = try? JSONDecoder().decode(AddResponse.self, from: data) else {
+          NSLog("Save Failed: (\(String(describing: requestInfo)))")
+          completion(.failure(.json))
+          return
+        }
+
+        completion(.success(saveJSON))
+
+      }
+    }
+
+    // Make call to save item to Pocket
+    NSLog("""
+      Attempt to save (\(String(describing: url)))
+      with access_token: (\(String(describing: access_token)))
+      """)
+
+
+  }
 }
+

--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -69,7 +69,7 @@ static func savePage(from page: SFSafariPage, access_token: String){
       // Status should be replaced with relevant data
       page.dispatchMessageToScript(
         withName: Dispatch.SAVE_TO_POCKET_REQUEST,
-        userInfo: ["item": status]
+        userInfo: nil
       )
 
 
@@ -93,7 +93,7 @@ static func savePage(from page: SFSafariPage, access_token: String){
           // Status should be replaced with relevant data
           page.dispatchMessageToScript(
             withName: Dispatch.SAVE_TO_POCKET_FAILURE,
-            userInfo: ["item": status]
+            userInfo: ["error": error]
           )
 
         }

--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -56,6 +56,36 @@ class Actions {
 
   }
 
+static func savePage(from page: SFSafariPage, access_token: String){
 
+    page.getPropertiesWithCompletionHandler { properties in
+
+      // Check we have a URL
+      guard let url = properties?.url?.absoluteString else {
+        NSLog("Invalid URL")
+        return
+      }
+
+      SaveToPocketAPI.saveToPocket(from: page, url: url, access_token: access_token) { result in
+
+        switch result {
+
+        case .success(let status):
+          NSLog("Page Saved: \(status)")
+
+        case .failure(let error):
+          NSLog("Page failed to save: \(error)")
+
+        }
+
+      }
+
+    }
+
+  }
+
+  static func saveLink(){
+
+  }
 
 } // End Actions

--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -66,15 +66,35 @@ static func savePage(from page: SFSafariPage, access_token: String){
         return
       }
 
+      // Status should be replaced with relevant data
+      page.dispatchMessageToScript(
+        withName: Dispatch.SAVE_TO_POCKET_REQUEST,
+        userInfo: ["item": status]
+      )
+
+
       SaveToPocketAPI.saveToPocket(from: page, url: url, access_token: access_token) { result in
 
         switch result {
 
         case .success(let status):
+
           NSLog("Page Saved: \(status)")
+
+          // Status should be replaced with relevant data
+          page.dispatchMessageToScript(
+            withName: Dispatch.SAVE_TO_POCKET_SUCCESS,
+            userInfo: ["item": status]
+          )
 
         case .failure(let error):
           NSLog("Page failed to save: \(error)")
+
+          // Status should be replaced with relevant data
+          page.dispatchMessageToScript(
+            withName: Dispatch.SAVE_TO_POCKET_FAILURE,
+            userInfo: ["item": status]
+          )
 
         }
 

--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -1,0 +1,61 @@
+//
+//  Actions.swift
+//  Save to Pocket Extension
+//
+//  Created by Joel Kelly on 8/20/19.
+//  Copyright © 2019 Pocket. All rights reserved.
+//
+
+import SafariServices
+
+class Actions {
+
+  static func logIn(from page: SFSafariPage){
+
+    Utilities.openBackgroundTab(
+      from: page,
+      userInfo: ["url" : "https://getpocket.com/signup?src=extension&route=/extension_login_success"]
+    )
+
+  }
+
+  static func logOut(from page: SFSafariPage) {
+
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: "access_token")
+
+  }
+
+  static func auth(from page: SFSafariPage, userInfo: [String : Any]?){
+
+    // Since we got the Auth Code from the passed in page, we close that page
+    Utilities.closeTab(from: page, userInfo: userInfo)
+
+    // Make an API call to validate the extension
+    SaveToPocketAPI.validateAuthCode(from: page, userInfo: userInfo) { result in
+
+      switch result {
+
+        case .success(let access_token):
+          NSLog("Validated auth code: \(access_token)")
+
+          SFSafariApplication.getActiveWindow { (window) in
+            window?.getActiveTab { (tab) in
+              tab?.getActivePage(completionHandler: { (page) in
+                self.savePage(from: page!, access_token: access_token)
+              })
+            }
+          }
+
+        case .failure(let error):
+          NSLog("Failed to validate auth code: \(error)")
+
+      }
+
+    }
+
+  }
+
+
+
+} // End Actions

--- a/_safari/Save to Pocket Extension/Common/Structures.swift
+++ b/_safari/Save to Pocket Extension/Common/Structures.swift
@@ -39,3 +39,9 @@ struct Profile: Decodable{
   let avatar_url: String?
 }
 
+struct Dispatch {
+  static let SAVE_TO_POCKET_REQUEST: String = "SAVE_TO_POCKET_REQUEST"
+  static let SAVE_TO_POCKET_SUCCESS: String = "SAVE_TO_POCKET_SUCCESS"
+  static let SAVE_TO_POCKET_FAILURE: String = "SAVE_TO_POCKET_FAILURE"
+
+}

--- a/_safari/Save to Pocket Extension/Common/Structures.swift
+++ b/_safari/Save to Pocket Extension/Common/Structures.swift
@@ -9,7 +9,12 @@
 struct GuidResponse: Decodable {
   let guid: String
 }
-//
+
+struct AddResponse: Decodable{
+  let status: Int
+}
+
+
 struct AuthResponse: Decodable{
   let access_token: String
   let username: String?

--- a/_safari/Save to Pocket Extension/Common/Utilities.swift
+++ b/_safari/Save to Pocket Extension/Common/Utilities.swift
@@ -56,24 +56,28 @@ class Utilities {
           JSONSerialization.isValidJSONObject(parameters),
           let jsonData = try? JSONSerialization.data(withJSONObject: parameters, options: .prettyPrinted) {
           urlRequest.httpBody = jsonData
+          
           urlRequest.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
           urlRequest.setValue("application/json", forHTTPHeaderField: "X-Accept")
         }
         
         // Make the request and capure the response
-        _ = URLSession.shared.dataTask(with: urlRequest){ data, response, error in
+          _ = URLSession.shared.dataTask(with: urlRequest){ data, response, error in
           // Once we get the response, check that it's valid?
+          
           if let restResponse = response as? HTTPURLResponse, restResponse.statusCode > 300 {
             completion(.failure(.statusCode))
             return
           }
+          
           guard let responseData = data else {
             completion(.failure(.error))
             return
           }
+            
           // Excellent—Pass on the data
           let string = String(data: responseData, encoding: String.Encoding.utf8)
-          NSLog("Auth Success (string): (\(String(describing: string!)))")
+          NSLog("Success (string): (\(String(describing: string!)))")
           completion(.success(responseData))
         }.resume()
       }

--- a/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
+++ b/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
@@ -75,7 +75,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         }
 
         // Hey AuthToken exists! Save the page
-        // MAKE CALL TO SAVE
+        Actions.savePage(from: page!, access_token: access_token)
 
         // DEV ONLY:  Remove that auth token
         Actions.logOut(from: page!)

--- a/_safari/Save to Pocket.xcodeproj/project.pbxproj
+++ b/_safari/Save to Pocket.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		314EF9902289D10400704C32 /* SafariExtensionViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 314EF98E2289D10400704C32 /* SafariExtensionViewController.xib */; };
 		314EF9952289D10400704C32 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 314EF9942289D10400704C32 /* ToolbarItemIcon.pdf */; };
 		5D0477E423071DF90026D77F /* login.js in Resources */ = {isa = PBXBuildFile; fileRef = 5D0477E323071DF90026D77F /* login.js */; };
+		5D20D3A1230CF13400496125 /* Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D20D3A0230CF13400496125 /* Actions.swift */; };
 		5D789155230B0E8100845FC2 /* Structures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D789154230B0E8100845FC2 /* Structures.swift */; };
 		5D789157230BA6B000845FC2 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D789156230BA6B000845FC2 /* API.swift */; };
 		5D8B90092306506200B9CF3E /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5D8B90082306506200B9CF3E /* Info.plist */; };
@@ -68,6 +69,7 @@
 		314EF9942289D10400704C32 /* ToolbarItemIcon.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = ToolbarItemIcon.pdf; sourceTree = "<group>"; };
 		314EF9962289D10400704C32 /* Save_to_Pocket_Extension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Save_to_Pocket_Extension.entitlements; sourceTree = "<group>"; };
 		5D0477E323071DF90026D77F /* login.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = login.js; sourceTree = "<group>"; };
+		5D20D3A0230CF13400496125 /* Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Actions.swift; sourceTree = "<group>"; };
 		5D789154230B0E8100845FC2 /* Structures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Structures.swift; sourceTree = "<group>"; };
 		5D789156230BA6B000845FC2 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		5D8B90082306506200B9CF3E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 			isa = PBXGroup;
 			children = (
 				5D789156230BA6B000845FC2 /* API.swift */,
+				5D20D3A0230CF13400496125 /* Actions.swift */,
 				5D93491523090EA600974849 /* Utilities.swift */,
 				5D789154230B0E8100845FC2 /* Structures.swift */,
 			);
@@ -290,6 +293,7 @@
 				5D93491623090EA600974849 /* Utilities.swift in Sources */,
 				FFAD317322CBBC39002C543F /* SafariExtensionHandler.swift in Sources */,
 				5D789155230B0E8100845FC2 /* Structures.swift in Sources */,
+				5D20D3A1230CF13400496125 /* Actions.swift in Sources */,
 				314EF98D2289D10400704C32 /* SafariExtensionViewController.swift in Sources */,
 				5D789157230BA6B000845FC2 /* API.swift in Sources */,
 			);


### PR DESCRIPTION
## Goal

Add Save to Pocket call to the Safari App Extension

## Todos:
- [x] Check for auth token
- [x] Dispatch a `SAVE_INITIATED` to the injected script
- [x] Make save call to the server
- [x] Handle successful save by passing save data to the injected script
- [x] Handle failed save by passing a failure message to the injected script

## Notes
This branch will be rebased once the PR #104 is completed, so that should be reviewed first.
