### PR TITLE
refactor(auth): idiomatic asynchronous dispatch

### DIFF
--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -6,107 +6,142 @@
 //  Copyright © 2019 Pocket. All rights reserved.
 //
 
-  // ✅ SUPPORT THESE FOR MVP
-  // ---------------------------------------
-  // authorize
-  // getGuid
+// ✅ SUPPORT THESE FOR MVP
+// ---------------------------------------
+// authorize
+// getGuid
 
-  // saveToPocket
-  // getOnSaveTags
+// saveToPocket
+// getOnSaveTags
 
-  // syncItemTags
-  // fetchStoredTags
+// syncItemTags
+// fetchStoredTags
 
-  // archiveItem
-  // removeItem
+// archiveItem
+// removeItem
 
-  // sendAnalytics
+// sendAnalytics
 
-  // 🙈 FAST FOLLOW WITH THESE
-  // ---------------------------------------
-  // getFeatures
+// 🙈 FAST FOLLOW WITH THESE
+// ---------------------------------------
+// getFeatures
 
-  // getRecommendations
-  // saveRecToPocket
-  // openRecommendation
+// getRecommendations
+// saveRecToPocket
+// openRecommendation
 
-  // sendSurvey
-  // sendSurveyAnalytics
+// sendSurvey
+// sendSurveyAnalytics
 
 import SafariServices
 
 class SaveToPocketAPI: SafariExtensionHandler{
-
-  static func getGuid(from page: SFSafariPage) -> String {
+  
+  static func getGuid(from page: SFSafariPage, completion: @escaping (Result<String, RequestError>) -> Void) -> Void {
     // Get authorized from server
     // Build request data dictionary
     let requestData: [String : Any] = [
       "consumer_key": "70018-b83d4728573df682a7c50b3d",
       "abt": "1"
     ]
-
+    
     let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/guid/",
                                        "method" : "GET",
                                        "parameters" : requestData
     ];
-
+    
     NSLog("Request Guid: (\(String(describing: requestInfo)))")
-    do{
-      let data = try Utilities.request(from: page, userInfo: requestInfo)
-      let guidJSON = try JSONDecoder().decode(GuidResponse.self, from: data!)
-      return guidJSON.guid
-    } catch {
-      NSLog("Request Failed: (\(String(describing: requestInfo)))")
-      return "This is not my guid"
+    Utilities.request(from: page, userInfo: requestInfo) { result in
+      switch result {
+      case .success(let data):
+        guard let guidJSON = try? JSONDecoder().decode(GuidResponse.self, from: data) else {
+          completion(.failure(.json))
+          return
+        }
+        completion(.success(guidJSON.guid))
+      case .failure(let error):
+        NSLog("Request Failed: (\(String(describing: requestInfo)))")
+        completion(.failure(error))
+      }
     }
   }
-
-  static func validateAuthCode(from page: SFSafariPage, userInfo: [String : Any]?) -> Void {
-
+  
+  static func validateAuthCode(from page: SFSafariPage, userInfo: [String : Any]?, completion: @escaping (Result<String, RequestError>) -> Void) -> Void {
+    
     // Since we got the Auth Code from the passed in page, we close that page
     Utilities.closeTab(from: page, userInfo: userInfo)
-
+    
     guard let userId = userInfo!["userId"] as? String, let token = userInfo!["token"] as? String  else {
       NSLog("Auth Tokens Missing: \(String(describing: userInfo))")
       return
     }
     NSLog("User ID: (\(String(describing: userId))) - Token: (\(String(describing: token))")
-
-    let guid = self.getGuid(from: page)
-    NSLog("GUID: \(String(describing: guid))")
-
-    // Get authorized from server
-    // Build request data dictionary
-    let requestData: [String : Any] = [
-      "consumer_key": "70018-b83d4728573df682a7c50b3d",
-      "guid": guid,
-      "token": token,
-      "user_id" : userId,
-      "account": "1",
-      "grant_type": "extension"
-    ]
-
-    let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/oauth/authorize.php",
-                                       "method" : "POST",
-                                       "parameters" : requestData
-    ];
-
-
-    NSLog("Auth Request: (\(String(describing: requestInfo)))")
-    do{
-      guard let data = try Utilities.request(from: page, userInfo: requestInfo) else {
-        throw RequestErrors.auth
+    
+    // Create a serial queue.
+    let queue = DispatchQueue(label: "API.validateAuthCode")
+    
+    // Run all requests within queue.
+    queue.async {
+      
+      var guid: String? = nil
+      var error: RequestError = .undefined
+      
+      let waitOnGuid = DispatchSemaphore(value: 0)
+      
+      getGuid(from: page) { result in
+        switch result {
+        case .failure(let e):
+          error = e
+        case .success(let g):
+          guid = g
+          NSLog("GUID: \(String(describing: guid))")
+          // Signal semaphore to unblock this queue.
+          waitOnGuid.signal()
+        }
       }
-
-      let authJSON = try JSONDecoder().decode(AuthResponse.self, from: data)
-
-      // Store Account data
-      let defaults = UserDefaults.standard
-      defaults.set(authJSON.access_token, forKey: "access_token")
-
-    } catch {
-      NSLog("Auth Failed: (\(String(describing: requestInfo)))")
+      
+      // We can block this queue without affecting the main thread.
+      _ = waitOnGuid.wait(timeout: .distantFuture)
+      
+      guard guid != nil else {
+        completion(.failure(error))
+        return
+      }
+      
+      // Get authorized from server
+      // Build request data dictionary
+      let requestData: [String : Any] = [
+        "consumer_key": "70018-b83d4728573df682a7c50b3d",
+        "guid": guid as Any,
+        "token": token,
+        "user_id" : userId,
+        "account": "1",
+        "grant_type": "extension"
+      ]
+      
+      
+      let requestInfo: [String : Any] = ["url" : "https://getpocket.com/v3/oauth/authorize.php",
+                                         "method" : "POST",
+                                         "parameters" : requestData
+      ];
+      
+      NSLog("Auth Request: (\(String(describing: requestInfo)))")
+      Utilities.request(from: page, userInfo: requestInfo) { result in
+        switch result {
+        case .failure(_):
+          NSLog("Auth Failed: (\(String(describing: requestInfo)))")
+        case .success(let data):
+          guard let authJSON = try? JSONDecoder().decode(AuthResponse.self, from: data) else {
+            NSLog("Auth Failed: (\(String(describing: requestInfo)))")
+            completion(.failure(.auth))
+            return
+          }
+          // Store Account data
+          let defaults = UserDefaults.standard
+          defaults.set(authJSON.access_token, forKey: "access_token")
+          completion(.success(authJSON.access_token))
+        }
+      }
     }
   }
-
 }

--- a/_safari/Save to Pocket Extension/Common/Utilities.swift
+++ b/_safari/Save to Pocket Extension/Common/Utilities.swift
@@ -65,6 +65,7 @@ class Utilities {
           // Once we get the response, check that it's valid?
           if let restResponse = response as? HTTPURLResponse, restResponse.statusCode > 300 {
             completion(.failure(.statusCode))
+            return
           }
           guard let responseData = data else {
             completion(.failure(.error))

--- a/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
+++ b/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
@@ -8,11 +8,14 @@
 
 import SafariServices
 
-enum RequestErrors: Error {
+enum RequestError: Error {
+  case undefined
   case auth
   case url
   case statusCode
   case error
+  /// Received invalid or unexpected JSON response data
+  case json
 }
 
 class SafariExtensionHandler: SFSafariExtensionHandler {
@@ -29,7 +32,14 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
       NSLog("Main Script Injected")
     
     case "AUTH_CODE_RECEIVED":
-      SaveToPocketAPI.validateAuthCode(from: page, userInfo: userInfo)
+      SaveToPocketAPI.validateAuthCode(from: page, userInfo: userInfo) { result in
+        switch result {
+        case .success(_):
+          NSLog("Auth code validated")
+        case .failure(let error):
+          NSLog("Failed to validate auth code: \(error)")
+        }
+      }
       
     default:
       page.getPropertiesWithCompletionHandler { properties in


### PR DESCRIPTION
## Goal

Use idiomatic asynchronous dispatch to avoid blocking the main CPU thread

## Todos:
- [x] `Utilities` does not inherit from `SafariExtensionHandler`
- [x] `Class` uses `class` functions (debatable) 
- [x] Refactor `Utilities.request` method to take a closure that will resolve the `Result` type
- [x] Rename `RequestErrors` => `RequestError`
- [x] Add `undefined` to `RequestError`
- [x] Refactor `API.validateAuthCode` to take a closure that will resolve the `Result` type
- [x] Refactor `API.getGuid` to take a closure that will resolve the `Result` type

## Implementation Decisions

The refactor of `API.request` makes it consistent with idiomatic Swift (insomuch as I know anything about Swift). In the `API.validateAuthCode` function, I created an example of how one can use a dedicated dispatch queue to use dispatch semaphores without blocking the main queue.

## All Submissions:

- [ ] Have you followed the guidelines in our Contributing document? 
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
