### PR TITLE
refactor(safari): adding basic client side render

### DIFF
--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -93,7 +93,7 @@ class Actions {
           // Status should be replaced with relevant data
           page.dispatchMessageToScript(
             withName: Dispatch.SAVE_TO_POCKET_SUCCESS,
-            userInfo: ["item": status]
+            userInfo: nil // FIX: passing anything other than nil breaks this
           )
 
         case .failure(let error):
@@ -102,7 +102,7 @@ class Actions {
           // Status should be replaced with relevant data
           page.dispatchMessageToScript(
             withName: Dispatch.SAVE_TO_POCKET_FAILURE,
-            userInfo: ["error": error]
+            userInfo: nil
           )
 
         }

--- a/_safari/Save to Pocket Extension/script.js
+++ b/_safari/Save to Pocket Extension/script.js
@@ -1,132 +1,149 @@
 /*global safari*/
+// import React from 'react'
+// import ReactDOM from 'react-dom'
 
-/* Dispatch messages to SAE
+;(function() {
+  if (window.top === window) {
+    let root // Temporary injection point
+
+    /* Dispatch messages to SAE
+  –––––––––––––––––––––––––––––––––––––––––––––––––– */
+    const MAIN_SCRIPT_INJECTED = 'MAIN_SCRIPT_INJECTED'
+    // const USER_LOG_IN = 'USER_LOG_IN'
+    // const USER_LOG_OUT = 'USER_LOG_OUT'
+    // const SAVE_PAGE_TO_POCKET = 'SAVE_PAGE_TO_POCKET'
+    // const SAVE_URL_TO_POCKET = 'SAVE_URL_TO_POCKET'
+
+    // const ARCHIVE_ITEM = 'ARCHIVE_ITEM'
+    // const REMOVE_ITEM = 'REMOVE_ITEM'
+    // const EDIT_TAGS = 'EDIT_TAGS'
+
+    /* Dispatched messages from SAE
+  –––––––––––––––––––––––––––––––––––––––––––––––––– */
+
+    const SAVE_TO_POCKET_REQUEST = 'SAVE_TO_POCKET_REQUEST'
+    const SAVE_TO_POCKET_SUCCESS = 'SAVE_TO_POCKET_SUCCESS'
+    const SAVE_TO_POCKET_FAILURE = 'SAVE_TO_POCKET_FAILURE'
+
+    const ARCHIVE_ITEM_SUCCESS = 'ARCHIVE_ITEM_SUCCESS'
+    const ARCHIVE_ITEM_FAILURE = 'ARCHIVE_ITEM_FAILURE'
+
+    const REMOVE_ITEM_SUCCESS = 'REMOVE_ITEM_SUCCESS'
+    const REMOVE_ITEM_FAILURE = 'REMOVE_ITEM_FAILURE'
+
+    const TAGS_ADDED_SUCCESS = 'TAGS_ADDED_SUCCESS'
+    const TAGS_ADDED_FAILURE = 'TAGS_ADDED_FAILURE'
+
+    const SUGGESTED_TAGS_SUCCESS = 'SUGGESTED_TAGS_SUCCESS'
+    const SUGGESTED_TAGS_FAILURE = 'SUGGESTED_TAGS_FAILURE'
+
+    const USER_LOG_IN_SUCCESS = 'USER_LOG_IN_SUCCESS'
+    const USER_LOG_IN_FAILURE = 'USER_LOG_IN_FAILURE'
+
+    const USER_LOG_OUT_SUCCESS = 'USER_LOG_OUT_SUCCESS'
+    const USER_LOG_OUT_FAILURE = 'USER_LOG_IN_FAILURE'
+
+    /* Add Safari Listeners
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-const MAIN_SCRIPT_INJECTED = 'MAIN_SCRIPT_INJECTED'
-// const USER_LOG_IN = 'USER_LOG_IN'
-// const USER_LOG_OUT = 'USER_LOG_OUT'
-// const SAVE_PAGE_TO_POCKET = 'SAVE_PAGE_TO_POCKET'
-// const SAVE_URL_TO_POCKET = 'SAVE_URL_TO_POCKET'
+    safari.self.addEventListener('message', handleMessage)
 
-// const ARCHIVE_ITEM = 'ARCHIVE_ITEM'
-// const REMOVE_ITEM = 'REMOVE_ITEM'
-// const EDIT_TAGS = 'EDIT_TAGS'
+    /* Handle incoming messages
+–––––––––––––––––––––––––––––––––––––––––––––––––– */
+    function handleMessage(event) {
+      const { message, name = 'Unknown Action' } = event || {}
+      console.log(event)
 
-/* Dispatched messages from SAE
+      switch (name) {
+        case SAVE_TO_POCKET_REQUEST: {
+          root.innerHTML = '<div><em>Saving</em></div>'
+          return
+        }
+
+        case SAVE_TO_POCKET_SUCCESS: {
+          root.innerHTML = '<div>Saved</div>'
+          return
+        }
+
+        case SAVE_TO_POCKET_FAILURE: {
+          root.innerHTML = '<div><em>Oops—Save Failed</em></div>'
+          return
+        }
+
+        case ARCHIVE_ITEM_SUCCESS: {
+          return
+        }
+
+        case ARCHIVE_ITEM_FAILURE: {
+          return
+        }
+
+        case REMOVE_ITEM_SUCCESS: {
+          return
+        }
+
+        case REMOVE_ITEM_FAILURE: {
+          return
+        }
+
+        case TAGS_ADDED_SUCCESS: {
+          return
+        }
+
+        case TAGS_ADDED_FAILURE: {
+          return
+        }
+
+        case SUGGESTED_TAGS_SUCCESS: {
+          return
+        }
+
+        case SUGGESTED_TAGS_FAILURE: {
+          return
+        }
+
+        case USER_LOG_IN_SUCCESS: {
+          return
+        }
+
+        case USER_LOG_IN_FAILURE: {
+          return
+        }
+
+        case USER_LOG_OUT_SUCCESS: {
+          return
+        }
+
+        case USER_LOG_OUT_FAILURE: {
+          return
+        }
+
+        default: {
+          console.groupCollapsed(name)
+          console.log(message)
+          console.groupEnd(name)
+          break
+        }
+      }
+    }
+
+    /* Initialize injected script
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 
-const SAVE_TO_POCKET_REQUEST = 'SAVE_TO_POCKET_REQUEST'
-const SAVE_TO_POCKET_SUCCESS = 'SAVE_TO_POCKET_SUCCESS'
-const SAVE_TO_POCKET_FAILURE = 'SAVE_TO_POCKET_FAILURE'
+    function setLoaded() {
+      const element = document.createElement('div')
+      element.id = 'pocket-extension-root'
 
-const ARCHIVE_ITEM_SUCCESS = 'ARCHIVE_ITEM_SUCCESS'
-const ARCHIVE_ITEM_FAILURE = 'ARCHIVE_ITEM_FAILURE'
+      root = document.body.appendChild(element)
+      root.innerHTML = '<div></div>'
 
-const REMOVE_ITEM_SUCCESS = 'REMOVE_ITEM_SUCCESS'
-const REMOVE_ITEM_FAILURE = 'REMOVE_ITEM_FAILURE'
-
-const TAGS_ADDED_SUCCESS = 'TAGS_ADDED_SUCCESS'
-const TAGS_ADDED_FAILURE = 'TAGS_ADDED_FAILURE'
-
-const SUGGESTED_TAGS_SUCCESS = 'SUGGESTED_TAGS_SUCCESS'
-const SUGGESTED_TAGS_FAILURE = 'SUGGESTED_TAGS_FAILURE'
-
-const USER_LOG_IN_SUCCESS = 'USER_LOG_IN_SUCCESS'
-const USER_LOG_IN_FAILURE = 'USER_LOG_IN_FAILURE'
-
-const USER_LOG_OUT_SUCCESS = 'USER_LOG_OUT_SUCCESS'
-const USER_LOG_OUT_FAILURE = 'USER_LOG_IN_FAILURE'
-
-/* Add Safari Listeners
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
-safari.self.addEventListener('message', handleMessage)
-
-/* Handle incoming messages
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
-function handleMessage(event) {
-  const { message, name = 'Unknown Action' } = event.message || {}
-
-  switch (message) {
-
-    case SAVE_TO_POCKET_REQUEST: {
-      return
-    }
-      
-    case SAVE_TO_POCKET_SUCCESS: {
-      return
+      safari.extension.dispatchMessage(MAIN_SCRIPT_INJECTED)
     }
 
-    case SAVE_TO_POCKET_FAILURE: {
-      return
-    }
-
-    case ARCHIVE_ITEM_SUCCESS: {
-      return
-    }
-
-    case ARCHIVE_ITEM_FAILURE: {
-      return
-    }
-
-    case REMOVE_ITEM_SUCCESS: {
-      return
-    }
-
-    case REMOVE_ITEM_FAILURE: {
-      return
-    }
-
-    case TAGS_ADDED_SUCCESS: {
-      return
-    }
-
-    case TAGS_ADDED_FAILURE: {
-      return
-    }
-
-    case SUGGESTED_TAGS_SUCCESS: {
-      return
-    }
-
-    case SUGGESTED_TAGS_FAILURE: {
-      return
-    }
-
-    case USER_LOG_IN_SUCCESS: {
-      return
-    }
-
-    case USER_LOG_IN_FAILURE: {
-      return
-    }
-
-    case USER_LOG_OUT_SUCCESS: {
-      return
-    }
-
-    case USER_LOG_OUT_FAILURE: {
-      return
-    }
-
-    default: {
-      console.groupCollapsed(name)
-      console.log(message)
-      console.groupEnd(name)
-      break
+    // Check page has loaded and if not add listener for it
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setLoaded)
+    } else {
+      setLoaded()
     }
   }
-}
-
-/* Initialize injected script
-–––––––––––––––––––––––––––––––––––––––––––––––––– */
-
-function setLoaded() {
-  safari.extension.dispatchMessage(MAIN_SCRIPT_INJECTED)
-}
-
-// Check page has loaded and if not add listener for it
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', setLoaded)
-} else {
-  setLoaded()
-}
+})()


### PR DESCRIPTION
## Goal
This is a quick round trip test that provides some basic feedback when a user saves to make sure the swift/client side bridge is operating successfully.

## Todos:
- [x] Add basic dispatch/receive
- [x] Adjust save page after auth

## Implementation Decisions
This is primarily to provide separation that will be required to get more help on the swift side as necessary while the client side is being worked out.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
