### PR TITLE
fix(safari): force guid to unwrap

### DIFF
--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -106,7 +106,7 @@ class SaveToPocketAPI: SafariExtensionHandler{
       // Build request data dictionary
       let requestData: [String : Any] = [
         "consumer_key": "70018-b83d4728573df682a7c50b3d",
-        "guid": guid as Any,
+        "guid": guid!,
         "token": token,
         "user_id" : userId,
         "account": "1",


### PR DESCRIPTION
## Goal
Auth was not functioning consistently

## Implementation Decisions
This forces the guid as opposed to having it sometimes return as optional as far as I can tell.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
