### PR TITLE
update(save): add js action info context parameters to api call

### DIFF
--- a/src/common/api/saving/archive.js
+++ b/src/common/api/saving/archive.js
@@ -2,7 +2,7 @@ import { request } from '../_request/request'
 
 /* API CALLS - Should return promises
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-export function archiveItem(access_token, itemId) {
+export function archiveItem(access_token, itemId, actionInfo) {
   return request({
     path: 'send/',
     data: {
@@ -10,7 +10,8 @@ export function archiveItem(access_token, itemId) {
       actions: [
         {
           action: 'archive',
-          item_id: itemId
+          item_id: itemId,
+          ...actionInfo
         }
       ]
     }

--- a/src/common/api/saving/remove.js
+++ b/src/common/api/saving/remove.js
@@ -2,7 +2,7 @@ import { request } from '../_request/request'
 
 /* API CALLS - Should return promises
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-export function removeItem(access_token, itemId) {
+export function removeItem(access_token, itemId, actionInfo) {
   return request({
     path: 'send/',
     data: {
@@ -11,7 +11,7 @@ export function removeItem(access_token, itemId) {
         {
           action: 'delete',
           item_id: itemId,
-          cxt_ui: 'newtab'
+          ...actionInfo
         }
       ]
     }

--- a/src/common/api/saving/save.js
+++ b/src/common/api/saving/save.js
@@ -12,6 +12,7 @@ export function saveToPocket(saveObject, access_token) {
           action: 'add',
           url: saveObject.url,
           title: saveObject.title,
+          ...saveObject.actionInfo,
           ...saveObject.additionalParams
         }
       ]


### PR DESCRIPTION
## Goal
Fix #139 

The purpose of this PR is to make sure that the analytics context data in the spec https://docs.google.com/spreadsheets/d/15YIc9n0eqOA9soD_NleEqED49Tqy5p4S9a5IHDN8BeI/edit#gid=0 is being passed along in the js api calls.

## Todos:
- [x] logged_in and authed_app automatically achieved by oauth backend
- [x] add
- [x] delete
- [x] archive

## Implementation Decisions
Update api action handlers to accept the context parameters and add them in the api call. 

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
