### PR TITLE
feat(safari): adding a save via context menu

### DIFF
--- a/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
+++ b/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
@@ -59,7 +59,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     case Receive.TAGS_SYNC:
       Actions.tagsSync(from: page, userInfo: userInfo)
       return
-    
+
     case Receive.OPEN_POCKET:
       Actions.openPocket(from: page)
       return
@@ -77,13 +77,11 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 
   override func contextMenuItemSelected(withCommand command: String, in page: SFSafariPage, userInfo: [String : Any]? = nil){
 
-    NSLog("Context with \(command) \(Receive.SAVE_TO_POCKET_CONTEXT)")
-
-    // Not sure this is viable to actuall receive url info
     if(command == Receive.SAVE_TO_POCKET_CONTEXT){
       NSLog("Save to pocket context with userInfo: \(String(describing: userInfo!))")
     }
 
+    Actions.saveFromContext(from: page, userInfo: userInfo)
   }
 
   override func messageReceivedFromContainingApp(withName messageName: String, userInfo: [String : Any]? = nil) {

--- a/src/containers/safari/dispatch.js
+++ b/src/containers/safari/dispatch.js
@@ -22,10 +22,17 @@ import { USER_LOG_OUT_FAILURE } from './actions'
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 export const dispatchInit = () => {
   safari.self.addEventListener('message', handleMessage)
+  document.addEventListener('contextmenu', handleContextMenu, false)
 }
 
 /* Handle incoming messages
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
+function handleContextMenu(event) {
+  const link = event.target.href
+  const urlToSave = link ? link : 'page'
+  safari.extension.setContextMenuEventUserInfo(event, { urlToSave })
+}
+
 function handleMessage(event) {
   const { message, name = 'Unknown Action' } = event || {}
 


### PR DESCRIPTION
## Goal
When a user right clicks on a link and selects `save to pocket`, the app should save that link.  If they click on a part of the page without a link, we should save the page they are clicking on.

## Todos:
- [x] Add context handler on the script side
- [x] Pass relevant info to the swift side 
- [x] Handle context save by routing it to a `savePage` or `saveLink`
- [x] Write save link functionality
- [x] Handle auth from contextual save


## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
