### PR TITLE
fix(twitter): adjust alignment on reply to tweet (FRONT-58, FRONT-59, FRONT-65)

### DIFF
--- a/src/containers/sites/twitter/twitter-util.js
+++ b/src/containers/sites/twitter/twitter-util.js
@@ -40,17 +40,15 @@ export function getPocketButtonClone({ permaLink, isFocusViewTweet }) {
 }
 
 export function getTweetLink($article) {
+  const linkElement = $article.querySelector('time').closest('a')
   let link
-
-  if($article.querySelector('[lang] > a')) {
-    link = $article.querySelector('[lang] > a').getAttribute('href')
+  if(linkElement) {
+    link = linkElement.href
   } else {
-    link = $article.querySelector('#tweet-rich-content-label a').getAttribute('href')
+    // is focus view
+    link = window.location.href
   }
-
-  const isExternalLink = link && link.match(/https?:/i)
-
-  return isExternalLink && link
+  return link
 }
 
 // Handle saving

--- a/src/containers/sites/twitter/twitter-util.js
+++ b/src/containers/sites/twitter/twitter-util.js
@@ -19,7 +19,8 @@ const saveToPocketMarkup = `
 const saveToPocketButton = document.createElement('div')
 saveToPocketButton.classList.add(
   'ProfileTweet-action',
-  'ProfileTweet-action--stp'
+  'ProfileTweet-action--stp',
+  styles.pocketIconWrapper
 )
 saveToPocketButton.innerHTML = saveToPocketMarkup
 
@@ -83,7 +84,7 @@ export function getTweetInfo(twitterActionListCotnainerElement) {
     permaLink = permaLinkFromLink
   }
 
-  const isFocusViewTweet = $tweet.getAttribute('data-testid') === 'tweetDetail'
+  const isFocusViewTweet = $tweet.querySelectorAll('[data-testid] [role=group]').length === 0
 
   return {
     permaLink,

--- a/src/containers/sites/twitter/twitter-util.js
+++ b/src/containers/sites/twitter/twitter-util.js
@@ -40,15 +40,14 @@ export function getPocketButtonClone({ permaLink, isFocusViewTweet }) {
 }
 
 export function getTweetLink($article) {
-  const linkElement = $article.querySelector('time').closest('a')
-  let link
-  if(linkElement) {
-    link = linkElement.href
+  const timeElement = $article.querySelector('time')
+  if(timeElement) {
+    const linkElement = timeElement.closest('a')
+    return linkElement.href
   } else {
     // is focus view
-    link = window.location.href
+    return window.location.pathname
   }
-  return link
 }
 
 // Handle saving
@@ -78,10 +77,11 @@ export function getTweetInfo(twitterActionListCotnainerElement) {
   }
 
   let permaLink = window.location.pathname
-  const $link = $tweet.querySelector('time').parentElement
-  const permaLinkFromLink = $link.getAttribute('href')
-  if (permaLinkFromLink) {
-    permaLink = permaLinkFromLink
+  const timeElement = $tweet.querySelector('time')
+  if (timeElement) {
+    const $link = timeElement.parentElement
+    const permaLinkFromLink = $link.getAttribute('href')
+    permaLink = permaLinkFromLink || permaLink
   }
 
   const isFocusViewTweet = $tweet.querySelector('[role=group] svg').getBoundingClientRect().width > 20

--- a/src/containers/sites/twitter/twitter-util.js
+++ b/src/containers/sites/twitter/twitter-util.js
@@ -32,7 +32,9 @@ export function getPocketButtonClone({ permaLink, isFocusViewTweet }) {
     .toString(36)
     .substring(7)}`
   pocketIconButtonClone.setAttribute('data-permalink-path', permaLink)
-  pocketIconButtonClone.classList.add(isFocusViewTweet ? styles['focus-view'] : styles['list-view'])
+  if(isFocusViewTweet) {
+    pocketIconButtonClone.classList.add(styles['focus-view'])
+  }
 
   return pocketIconButtonClone
 }

--- a/src/containers/sites/twitter/twitter-util.js
+++ b/src/containers/sites/twitter/twitter-util.js
@@ -86,7 +86,7 @@ export function getTweetInfo(twitterActionListCotnainerElement) {
     permaLink = permaLinkFromLink
   }
 
-  const isFocusViewTweet = $tweet.querySelectorAll('[data-testid] [role=group]').length === 0
+  const isFocusViewTweet = $tweet.querySelector('[role=group] svg').getBoundingClientRect().width > 20
 
   return {
     permaLink,

--- a/src/containers/sites/twitter/twitter-util.js
+++ b/src/containers/sites/twitter/twitter-util.js
@@ -101,7 +101,8 @@ export function addPocketIconToActionList({
   twitterActionListCotnainerElement,
   pocketIconButtonClone
 }) {
-  const shareAction = twitterActionListCotnainerElement.children[3]
+  const lastChildIndex = twitterActionListCotnainerElement.children.length - 1
+  const shareAction = twitterActionListCotnainerElement.children[lastChildIndex]
   shareAction.after(pocketIconButtonClone)
   twitterActionListCotnainerElement.classList.add('PocketAdded')
 }

--- a/src/containers/sites/twitter/twitter.js
+++ b/src/containers/sites/twitter/twitter.js
@@ -44,13 +44,15 @@ function stopIntegration() {
 function handleNewItems() {
   const tweetActionLists = document.querySelectorAll('[role=group]:not(.PocketAdded)')
   if (!tweetActionLists.length) return
-  try {
-    Array.from(tweetActionLists, addPocketFunctionality)
-  } catch ({ message }) {
-    if(message !== 'legacyTwitter') {
-      console.warn(message)
+  tweetActionLists.forEach(tweetActionListItem => {
+    try {
+      addPocketFunctionality(tweetActionListItem)
+    } catch ({ message }) {
+      if(message !== 'legacyTwitter') {
+        console.warn(message)
+      }
     }
-  }
+  })
 }
 
 // inject pocket icon among twitter action elements in the tweet action list container

--- a/src/containers/sites/twitter/twitter.scss
+++ b/src/containers/sites/twitter/twitter.scss
@@ -24,6 +24,7 @@
   position: relative;
   width: 24%;
   text-align: right;
+  margin: auto 0px;
 }
 .pocketIconContainer {
   cursor: pointer;
@@ -44,7 +45,6 @@
 
 .focus-view {
   text-align: left;
-  margin: auto 0px;
   zoom: 1.2;
 }
 

--- a/src/containers/sites/twitter/twitter.scss
+++ b/src/containers/sites/twitter/twitter.scss
@@ -14,15 +14,20 @@
     display: none;
   }
 }
+.pocketIconWrapper {
+  position: relative;
+  width: 35px;
+}
 .pocketIconContainer {
   cursor: pointer;
-  position: relative;
   border-radius: 100%;
   width: 35px;
   height: 35px;
-  position: relative;
+  position: absolute;
   left: -5px;
   transition: background 200ms;
+  margin-top: -2px;
+
   &:hover {
     background: #ef405630;
     .pocketIconStroke {
@@ -33,11 +38,12 @@
     @include show-fill;
   }
   .list-view & {
-    margin-top: -2px;
+    left: -23px;
+    top: -3px;
   }
   .focus-view & {
-    margin-top: 5px;
     zoom: 1.1;
+    top: 6px;
   }
 }
 

--- a/src/containers/sites/twitter/twitter.scss
+++ b/src/containers/sites/twitter/twitter.scss
@@ -29,11 +29,24 @@
 .pocketIconContainer {
   cursor: pointer;
   border-radius: 100%;
-  display: inline;
+  display: inline-block;
   transition: background 200ms;
-
+  &:after {
+    content: ' ';
+    width: 39%;
+    height: 140%;
+    display: none;
+    position: absolute;
+    left: 60px;
+    top: -5px;
+    z-index: -1;
+    border-radius: 100%;
+  }
   &:hover {
-    background: #ef405630;
+    &:after {
+      display: block;
+      background: #ef405630;
+    }
     .pocketIconStroke {
       fill: #ef4056;
     }
@@ -46,6 +59,11 @@
 .focus-view {
   text-align: left;
   zoom: 1.2;
+  .pocketIconContainer {
+    &:after {
+      left: -6px;
+    }
+  }
 }
 
 @include show-stroke;

--- a/src/containers/sites/twitter/twitter.scss
+++ b/src/containers/sites/twitter/twitter.scss
@@ -16,7 +16,8 @@
 }
 .pocketIconWrapper {
   position: relative;
-  width: 35px;
+  width: 70px;
+  left: 70px;
 }
 .pocketIconContainer {
   cursor: pointer;

--- a/src/containers/sites/twitter/twitter.scss
+++ b/src/containers/sites/twitter/twitter.scss
@@ -22,7 +22,7 @@
 }
 .pocketIconWrapper {
   position: relative;
-  width: 24%;
+  width: 20%;
   text-align: right;
   margin: auto 0px;
 }

--- a/src/containers/sites/twitter/twitter.scss
+++ b/src/containers/sites/twitter/twitter.scss
@@ -1,6 +1,11 @@
+@mixin icon-style {
+  position: relative;
+  top: 2px;
+}
 @mixin show-stroke {
   .pocketIconStroke {
     display: inline-block;
+    @include icon-style;
   }
   .pocketIconFill {
     display: none;
@@ -9,6 +14,7 @@
 @mixin show-fill {
   .pocketIconFill {
     display: inline-block;
+    @include icon-style;
   }
   .pocketIconStroke {
     display: none;
@@ -16,18 +22,14 @@
 }
 .pocketIconWrapper {
   position: relative;
-  width: 70px;
-  left: 70px;
+  width: 24%;
+  text-align: right;
 }
 .pocketIconContainer {
   cursor: pointer;
   border-radius: 100%;
-  width: 35px;
-  height: 35px;
-  position: absolute;
-  left: -5px;
+  display: inline;
   transition: background 200ms;
-  margin-top: -2px;
 
   &:hover {
     background: #ef405630;
@@ -38,27 +40,13 @@
   .saved & {
     @include show-fill;
   }
-  .list-view & {
-    left: -23px;
-    top: -3px;
-  }
   .focus-view & {
     zoom: 1.1;
-    top: 6px;
   }
 }
 
 @include show-stroke;
 
-.pocketIconStroke,
-.pocketIconFill {
-  height: 16px;
-  vertical-align: bottom;
-  width: 16px;
-  position: relative;
-  top: 10px;
-  left: 9px;
-}
 .pocketIconStroke {
   fill: rgb(136, 153, 166);
 }

--- a/src/containers/sites/twitter/twitter.scss
+++ b/src/containers/sites/twitter/twitter.scss
@@ -40,9 +40,12 @@
   .saved & {
     @include show-fill;
   }
-  .focus-view & {
-    zoom: 1.1;
-  }
+}
+
+.focus-view {
+  text-align: left;
+  margin: auto 0px;
+  zoom: 1.2;
 }
 
 @include show-stroke;

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -1,5 +1,5 @@
 name: 'Save to Pocket'
-version: 3.0.6.8
+version: 3.0.6.9
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"


### PR DESCRIPTION
## Goal
Fix https://getpocket.atlassian.net/browse/POC19-1719 

**Do not merge until develop and master are reconciled**

Fix twitter alignment with analytics tweet action icon

## Todos:
- [x] update focus vs list view logic
- [x] create parent wrapper style and use relative positioning and fixed width
- [x] update list and focus view styles to achieve alignment
- [x] fix alignment again (styles broke again)
- [x] investigate why the alignment broke
- [x] find a better solution than a style patch
- [x] remove manual positioning and margins
- [x] fix alignment with buffer extension enabled
- [x] fix focus view alignment 
- [x] fix missing tweets
- [x] fix hover state

<img width="1263" alt="Screen Shot 2020-01-05 at 9 49 34 PM" src="https://user-images.githubusercontent.com/1546207/71907202-886d9000-3139-11ea-8cfc-ee3ce0ca0614.png">

<img width="606" alt="Screen Shot 2020-01-07 at 1 48 02 PM" src="https://user-images.githubusercontent.com/1546207/71920350-849b3700-3154-11ea-808c-f962bb8f1f1f.png">
<img width="610" alt="Screen Shot 2020-01-07 at 1 47 12 PM" src="https://user-images.githubusercontent.com/1546207/71920351-849b3700-3154-11ea-857e-f2fa50bb2923.png">
<img width="883" alt="Screen Shot 2020-01-07 at 1 31 14 PM" src="https://user-images.githubusercontent.com/1546207/71920353-8533cd80-3154-11ea-8d94-652fba1132c0.png">


### How to test locally
https://pocket.slack.com/files/UBAQXP3N3/FHC1HG4MQ/Testing_extension_release_candidate_locally


## Implementation Decisions
Update the logic to determine if a tweet is focus vs list view as the **data-testid** tweetDetail attribute value is deprecated. Now looking for a role=group in the tweet to determine if it is focus or list view.
```  const isFocusViewTweet = $tweet.find('[data-testid=tweet] [role=group]').length === 0
```
I removed as well the manual positioning and margins to allow the svg to flow automatically in the layout


## Notes

Relies on #87.  Please rebase and merge once that branch has been approved.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
