### PR TITLE
Feat/analytics tagging context

### DIFF
--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -353,6 +353,8 @@ class SaveToPocketAPI: SafariExtensionHandler{
     from page: SFSafariPage,
     item_id: String,
     tags: Array<Any>,
+    suggestedCount: Int,
+    usedSuggestedCount: Int,
     access_token: String,
     premium_status: String,
     completion: @escaping (Result<Any, RequestError>) -> Void
@@ -362,17 +364,21 @@ class SaveToPocketAPI: SafariExtensionHandler{
     let addTagsAction: [String : Any] = [
       "action": "tags_add",
       "item_id": item_id,
-      "tags": tags
+      "tags": tags,
+      "cxt_ui": "toolbar",
+      "cxt_view": "ext_popover",
+      "cxt_premium_status": premium_status,
+      "cxt_remove_cnt": 0,
+      "cxt_enter_cnt": tags.count,
+      "cxt_suggested_available": suggestedCount,
+      "cxt_suggested_cnt": usedSuggestedCount
     ]
 
     // Build request data dictionary
     let requestData: [String : Any] = [
       "consumer_key": "70018-b83d4728573df682a7c50b3d",
       "access_token": access_token,
-      "actions": [addTagsAction],
-      "cxt_ui": "toolbar",
-      "cxt_view": "ext_popover",
-      "cxt_premium_status": premium_status
+      "actions": [addTagsAction]
     ]
 
 

--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -396,6 +396,10 @@ class Actions {
       return
     }
 
+    let suggestedCount = userInfo?["suggestedCount"] as? Int ?? 0
+
+    let usedSuggestedCount = userInfo?["usedSuggestedCount"] as? Int ?? 0
+
     NSLog("Sync tags: \(String(describing: tags))")
 
     // Make an API call to validate the extension
@@ -403,6 +407,8 @@ class Actions {
       from: page,
       item_id: item_id,
       tags: tags,
+      suggestedCount: suggestedCount,
+      usedSuggestedCount: usedSuggestedCount,
       access_token: access_token,
       premium_status: premium_status) { result in
 

--- a/src/common/api/saving/tags.js
+++ b/src/common/api/saving/tags.js
@@ -11,11 +11,11 @@ export function getOnSaveTags(saveObject) {
   }).then(response => [{ saveObject, status: 'ok', response }])
 }
 
-export function syncItemTags(id, tags) {
+export function syncItemTags(id, tags, actionInfo) {
   return request({
     path: 'send/',
     data: {
-      actions: [{ action: 'tags_add', item_id: id, tags }]
+      actions: [{ action: 'tags_add', item_id: id, tags, ...actionInfo }]
     }
   }).then(response => response)
 }

--- a/src/containers/safari/tags.state.js
+++ b/src/containers/safari/tags.state.js
@@ -141,7 +141,7 @@ function* tagChanges() {
     suggestedCount: suggested.length,
     usedSuggestedCount: usedSuggested.length
   }
-  if (taggingState) {
+  if (used.length) {
     safari.extension.dispatchMessage(TAGS_SYNC, payload)
   }
 }

--- a/src/containers/safari/tags.state.js
+++ b/src/containers/safari/tags.state.js
@@ -118,10 +118,13 @@ export const tagsSagas = [
 
 /* SAGAS :: SELECTORS
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
-const getTaggingPayload = state => {
+const getTaggingState = state => {
+  const { suggested, used } = state.tags
+
   return {
     item_id: state.saves.item_id,
-    tags: state.tags.used
+    used,
+    suggested
   }
 }
 
@@ -129,9 +132,16 @@ const getTaggingPayload = state => {
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 function* tagChanges() {
   yield delay(1000)
-  const payload = yield select(getTaggingPayload)
-
-  if (payload) {
+  const taggingState = yield select(getTaggingState)
+  const { used, suggested, item_id } = taggingState
+  const usedSuggested = used.filter(usedTag => suggested.includes(usedTag))
+  const payload = {
+    item_id,
+    tags: used,
+    suggestedCount: suggested.length,
+    usedSuggestedCount: usedSuggested.length
+  }
+  if (taggingState) {
     safari.extension.dispatchMessage(TAGS_SYNC, payload)
   }
 }

--- a/src/containers/safari/tags.state.js
+++ b/src/containers/safari/tags.state.js
@@ -134,11 +134,11 @@ function* tagChanges() {
   yield delay(1000)
   const taggingState = yield select(getTaggingState)
   const { used, suggested, item_id } = taggingState
-  const usedSuggested = used.length ? used.filter(usedTag => suggested.includes(usedTag)) : []
+  const usedSuggested = used.filter(usedTag => suggested.includes(usedTag))
   const payload = {
     item_id,
     tags: used,
-    suggestedCount: used.length ? suggested.length : 0,
+    suggestedCount: suggested.length,
     usedSuggestedCount: usedSuggested.length
   }
   if (taggingState) {

--- a/src/containers/safari/tags.state.js
+++ b/src/containers/safari/tags.state.js
@@ -134,11 +134,11 @@ function* tagChanges() {
   yield delay(1000)
   const taggingState = yield select(getTaggingState)
   const { used, suggested, item_id } = taggingState
-  const usedSuggested = used.filter(usedTag => suggested.includes(usedTag))
+  const usedSuggested = used.length ? used.filter(usedTag => suggested.includes(usedTag)) : []
   const payload = {
     item_id,
     tags: used,
-    suggestedCount: suggested.length,
+    suggestedCount: used.length ? suggested.length : 0,
     usedSuggestedCount: usedSuggested.length
   }
   if (taggingState) {

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -243,5 +243,5 @@ function* tagChanges() {
     cxt_ui: 'toolbar',
     cxt_view: 'ext_popover'
   }
-  yield call(API.syncItemTags, tagInfo.id, tagInfo.tags, { actionInfo })
+  yield call(API.syncItemTags, tagInfo.id, tagInfo.tags, actionInfo )
 }

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -244,15 +244,10 @@ function* tagChanges() {
   })
 
   const { suggested, used } = activeTags
-  const usedSuggested = used.reduce((curr, usedTag) => {
-    if(suggested.includes(usedTag)) {
-      curr.push(usedTag)
-    }
-    return usedTag
-  }, [])
+  const usedSuggested = used.length ? used.filter(usedTag => suggested.includes(usedTag)) : []
 
   const actionInfo = {
-    cxt_suggested_available: suggested.length,
+    cxt_suggested_available: used.length ? suggested.length : 0,
     cxt_enter_cnt: used.length,
     cxt_suggested_cnt: usedSuggested.length,
     cxt_remove_cnt: 0,

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -198,6 +198,10 @@ const getCurrentSetup = state => {
   return state.setup
 }
 
+const getActiveTags = state => {
+  return state.tags[state.active]
+}
+
 function* tagSuggestions(action) {
   try {
     const tagData = yield call(
@@ -218,6 +222,7 @@ function* tagSuggestions(action) {
 }
 
 function* tagChanges() {
+  const activeTags = yield select(getActiveTags)
   const setup = yield select(getCurrentSetup)
   const cxt_premium_status = setup.account_premium
 
@@ -238,7 +243,19 @@ function* tagChanges() {
     tabId: tagInfo.tabId
   })
 
+  const { suggested, used } = activeTags
+  const usedSuggested = used.reduce((curr, usedTag) => {
+    if(suggested.includes(usedTag)) {
+      curr.push(usedTag)
+    }
+    return usedTag
+  }, [])
+
   const actionInfo = {
+    cxt_suggested_available: suggested.length,
+    cxt_enter_cnt: used.length,
+    cxt_suggested_cnt: usedSuggested.length,
+    cxt_remove_cnt: 0,
     cxt_premium_status,
     cxt_ui: 'toolbar',
     cxt_view: 'ext_popover'

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -244,12 +244,7 @@ function* tagChanges() {
   })
 
   const { suggested, used } = activeTags
-  const usedSuggested = used.reduce((curr, usedTag) => {
-    if(suggested.includes(usedTag)) {
-      curr.push(usedTag)
-    }
-    return usedTag
-  }, [])
+  const usedSuggested = used.filter(usedTag => suggested.includes(usedTag))
 
   const actionInfo = {
     cxt_suggested_available: suggested.length,

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -194,6 +194,10 @@ const getStoredTags = state => {
   return state.setup.tags_stored || []
 }
 
+const getCurrentSetup = state => {
+  return state.setup
+}
+
 function* tagSuggestions(action) {
   try {
     const tagData = yield call(
@@ -214,6 +218,9 @@ function* tagSuggestions(action) {
 }
 
 function* tagChanges() {
+  const setup = yield select(getCurrentSetup)
+  const cxt_premium_status = setup.account_premium
+
   const tagInfo = yield select(getUsedTags)
   yield delay(2000)
 
@@ -231,5 +238,8 @@ function* tagChanges() {
     tabId: tagInfo.tabId
   })
 
-  yield call(API.syncItemTags, tagInfo.id, tagInfo.tags)
+  const actionInfo = {
+    cxt_premium_status
+  }
+  yield call(API.syncItemTags, tagInfo.id, tagInfo.tags, { actionInfo })
 }

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -239,7 +239,9 @@ function* tagChanges() {
   })
 
   const actionInfo = {
-    cxt_premium_status
+    cxt_premium_status,
+    cxt_ui: 'toolbar',
+    cxt_view: 'ext_popover'
   }
   yield call(API.syncItemTags, tagInfo.id, tagInfo.tags, { actionInfo })
 }

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -244,10 +244,15 @@ function* tagChanges() {
   })
 
   const { suggested, used } = activeTags
-  const usedSuggested = used.length ? used.filter(usedTag => suggested.includes(usedTag)) : []
+  const usedSuggested = used.reduce((curr, usedTag) => {
+    if(suggested.includes(usedTag)) {
+      curr.push(usedTag)
+    }
+    return usedTag
+  }, [])
 
   const actionInfo = {
-    cxt_suggested_available: used.length ? suggested.length : 0,
+    cxt_suggested_available: suggested.length,
     cxt_enter_cnt: used.length,
     cxt_suggested_cnt: usedSuggested.length,
     cxt_remove_cnt: 0,


### PR DESCRIPTION
## Goal

Fix #120 

Add analytics context for tagging based on spec for tags_add row here https://docs.google.com/spreadsheets/d/15YIc9n0eqOA9soD_NleEqED49Tqy5p4S9a5IHDN8BeI/edit#gid=0

## Todos:
- [x] setup action info for sync item tags api
- [x] add cxt_premium, cxt_view, cxt_ui params
- [x] add cxt_suggested_available param: *number of suggested tags* 
- [x] add cxt_enter_cnt param: *count of tags added via the text field* 
- [x] add cxt_suggested_cnt param: *count of tags added via the suggested tags*
- [x] add cxt_remove_cnt param: *count of tags removed from the "live tags" box*


## Implementation Decisions
• Following the same pattern as was done in #140 to ensure context parameters are set for each action in the same level as the action object in the actions array.
• Using #159 as a basis for determining changes required as the safari build cannot be tested in chrome.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
