### PR TITLE
fix(safari): remove item action

### DIFF
--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -210,7 +210,7 @@ class SaveToPocketAPI: SafariExtensionHandler{
 
     // Build Action
     let removeAction: [String : Any] = [
-      "action": "remove",
+      "action": "delete",
       "item_id": item_id
     ]
 


### PR DESCRIPTION
## Goal
Remove item was passing the wrong action type to the send api.  This fixes that.

## Todos:
- [x] Pass in the correct action

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
