### PR TITLE
feat(safari): open 'My List' on invalid url (new tab)

### DIFF
--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -118,6 +118,8 @@ class Actions {
       // Check we have a URL
       guard let url = properties?.url?.absoluteString else {
         NSLog("Invalid URL")
+        // Redirect to Pocket Site
+        Actions.openPocket(from: page)
         return
       }
 


### PR DESCRIPTION
## Goal
If the user selects the pocket toolbar on an invalid url we should open their list

## Todos:
- [x] open 'my list' on invalid URL as opposed to failing silently

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
