### PR TITLE
feat(safari): log out of extension when logging out of web app

### DIFF
--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -18,7 +18,7 @@ class Actions {
     Utilities.openTab(
       from: page,
       userInfo: ["url" : "https://getpocket.com/signup?src=extension&route=/extension_login_success"],
-      makeActive: false
+      makeActive: true
     )
 
   }

--- a/_safari/Save to Pocket Extension/Common/Structures.swift
+++ b/_safari/Save to Pocket Extension/Common/Structures.swift
@@ -90,4 +90,5 @@ struct Receive {
   static let REMOVE_ITEM_REQUEST: String = "REMOVE_ITEM_REQUEST"
   static let TAGS_SYNC: String = "TAGS_SYNC"
   static let OPEN_POCKET: String = "OPEN_POCKET"
+  static let LOGGED_OUT_OF_POCKET: String = "LOGGED_OUT_OF_POCKET"
 }

--- a/_safari/Save to Pocket Extension/Info.plist
+++ b/_safari/Save to Pocket Extension/Info.plist
@@ -48,6 +48,14 @@
 					<string>https://getpocket.com/extension_login_success</string>
 				</array>
 			</dict>
+			<dict>
+				<key>Script</key>
+				<string>logout.js</string>
+				<key>Allowed URL Patterns</key>
+				<array>
+					<string>https://getpocket.com/login</string>
+				</array>
+			</dict>
 		</array>
 		<key>SFSafariContextMenu</key>
 		<array>

--- a/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
+++ b/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
@@ -40,6 +40,10 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
       Actions.logOut(from: page)
       return
 
+    case Receive.LOGGED_OUT_OF_POCKET:
+      Actions.logOut(from: page)
+      return
+      
     case Receive.SAVE_PAGE_TO_POCKET:
       Actions.savePage(from: page)
       return

--- a/_safari/Save to Pocket Extension/logout.js
+++ b/_safari/Save to Pocket Extension/logout.js
@@ -1,0 +1,14 @@
+/*global safari*/
+
+// Check page has loaded and if not add listener for it
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setLogoutLoaded)
+} else {
+  setLogoutLoaded()
+}
+
+function setLogoutLoaded() {
+  setTimeout(function() {
+    safari.extension.dispatchMessage('LOGGED_OUT_OF_POCKET')
+  }, 500)
+}

--- a/_safari/Save to Pocket.xcodeproj/project.pbxproj
+++ b/_safari/Save to Pocket.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		5D0D0518231D948D00F13C12 /* safari.js in Resources */ = {isa = PBXBuildFile; fileRef = 5D0D0516231D948D00F13C12 /* safari.js */; };
 		5D0D0519231D948D00F13C12 /* vendors~safari.chunk.js in Resources */ = {isa = PBXBuildFile; fileRef = 5D0D0517231D948D00F13C12 /* vendors~safari.chunk.js */; };
 		5D20D3A1230CF13400496125 /* Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D20D3A0230CF13400496125 /* Actions.swift */; };
+		5D59099523315BE5005C6245 /* logout.js in Resources */ = {isa = PBXBuildFile; fileRef = 5D59099423315BE5005C6245 /* logout.js */; };
 		5D789155230B0E8100845FC2 /* Structures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D789154230B0E8100845FC2 /* Structures.swift */; };
 		5D789157230BA6B000845FC2 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D789156230BA6B000845FC2 /* API.swift */; };
 		5D93491623090EA600974849 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D93491523090EA600974849 /* Utilities.swift */; };
@@ -122,6 +123,7 @@
 		5D0D0516231D948D00F13C12 /* safari.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = safari.js; path = ../../build/js/safari.js; sourceTree = "<group>"; };
 		5D0D0517231D948D00F13C12 /* vendors~safari.chunk.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = "vendors~safari.chunk.js"; path = "../../build/js/vendors~safari.chunk.js"; sourceTree = "<group>"; };
 		5D20D3A0230CF13400496125 /* Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Actions.swift; sourceTree = "<group>"; };
+		5D59099423315BE5005C6245 /* logout.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = logout.js; sourceTree = "<group>"; };
 		5D789154230B0E8100845FC2 /* Structures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Structures.swift; sourceTree = "<group>"; };
 		5D789156230BA6B000845FC2 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		5D93491523090EA600974849 /* Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
@@ -200,6 +202,7 @@
 				314EF98C2289D10400704C32 /* SafariExtensionViewController.swift */,
 				314EF98E2289D10400704C32 /* SafariExtensionViewController.xib */,
 				314EF9942289D10400704C32 /* ToolbarItemIcon.pdf */,
+				5D59099423315BE5005C6245 /* logout.js */,
 				5D0477E323071DF90026D77F /* login.js */,
 				5D0D0516231D948D00F13C12 /* safari.js */,
 				5D0D0517231D948D00F13C12 /* vendors~safari.chunk.js */,
@@ -335,6 +338,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5D59099523315BE5005C6245 /* logout.js in Resources */,
 				5D0477E423071DF90026D77F /* login.js in Resources */,
 				311869D0231C7F6200B8C29D /* InfoPlist.strings in Resources */,
 				5D0D0518231D948D00F13C12 /* safari.js in Resources */,


### PR DESCRIPTION
## Goal
When user logs out of the web app, we should also log them out of the extension.

## Todos:
- [x] Add logout.js
- [x] Add message case for user logging out of pocket web app
- [x] Handle 'LOGGED_OUT_OF_POCKET'  message by destroying auth token

## Implementation Decisions
We are simply injecting a script into the specific url `https://getpocket.com/login`.  This is similar to how we do it on chrome with the exception of the query params `?e=4` This is because the Allowed URL Patterns do not support query parameters.  

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
