### PR TITLE
fix(safari): check dom on save request

### DIFF
--- a/src/containers/safari/dispatch.js
+++ b/src/containers/safari/dispatch.js
@@ -18,6 +18,8 @@ import { USER_LOG_IN_FAILURE } from './actions'
 import { USER_LOG_OUT_SUCCESS } from './actions'
 import { USER_LOG_OUT_FAILURE } from './actions'
 
+import { injectDomElements } from './inject'
+
 /* Add Safari Listeners
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 export const dispatchInit = () => {
@@ -36,12 +38,14 @@ function handleContextMenu(event) {
 function handleMessage(event) {
   const { message, name = 'Unknown Action' } = event || {}
 
-  console.groupCollapsed(name)
+  console.groupCollapsed(`RECEIVE: ${name}`)
   console.log(message)
-  console.groupEnd(name)
+  console.groupEnd(`RECEIVE: ${name}`)
 
   switch (name) {
     case SAVE_TO_POCKET_REQUEST: {
+      injectDomElements() // Check for DOM elements
+
       store.dispatch({ type: SAVE_TO_POCKET_REQUEST })
       return
     }

--- a/src/containers/safari/inject.js
+++ b/src/containers/safari/inject.js
@@ -9,35 +9,42 @@ import { MAIN_SCRIPT_INJECTED } from 'containers/safari/actions'
 import { Provider } from 'react-redux'
 import { store } from './store'
 //
+
+export function injectDomElements() {
+  const existingRoot = document.getElementById('pocket-extension-root')
+  if (existingRoot) return
+
+  const rootElement = document.createElement('div')
+  rootElement.id = 'pocket-extension-root'
+  const root = document.body.appendChild(rootElement)
+
+  const stylesElement = document.createElement('div')
+  stylesElement.id = 'pocket-extension-styles'
+  const styles = document.body.appendChild(stylesElement)
+
+  const myCache = createCache({
+    key: 'pocket',
+    container: styles
+  })
+
+  ReactDOM.render(
+    <Provider store={store}>
+      <CacheProvider value={myCache}>
+        <SafariApp />
+      </CacheProvider>
+    </Provider>,
+    root,
+    () => {
+      safari.extension.dispatchMessage(MAIN_SCRIPT_INJECTED)
+    }
+  )
+}
+
 ;(function() {
   if (window.top === window) {
     function setLoaded() {
       dispatchInit()
-
-      const rootElement = document.createElement('div')
-      rootElement.id = 'pocket-extension-root'
-      const root = document.body.appendChild(rootElement)
-
-      const stylesElement = document.createElement('div')
-      stylesElement.id = 'pocket-extension-styles'
-      const styles = document.body.appendChild(stylesElement)
-
-      const myCache = createCache({
-        key: 'pocket',
-        container: styles
-      })
-
-      ReactDOM.render(
-        <Provider store={store}>
-          <CacheProvider value={myCache}>
-            <SafariApp />
-          </CacheProvider>
-        </Provider>,
-        root,
-        () => {
-          safari.extension.dispatchMessage(MAIN_SCRIPT_INJECTED)
-        }
-      )
+      injectDomElements()
     }
 
     // Check page has loaded and if not add listener for it


### PR DESCRIPTION
## Goal
On single page apps, the DOM injection has the potential of getting wiped out.  This makes a check that we have the injected DOM elements on every save request.  If we have them, we do nothing, if they are absent we inject them.

## Todos:
- [x] Separate the DOM injection into an exportable function
- [x] Add DOM check to injection function
- [x] Call DOM Inject on `SAVE_TO_POCKET_REQUEST`

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
