### PR TITLE
Fix/analytics context on save for cxt_ui param

### DIFF
--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -170,6 +170,7 @@ class SaveToPocketAPI: SafariExtensionHandler{
       "action": "add",
       "url": url,
       "cxt_ui": ui_context,
+      "cxt_view": "ext_popover",
       "cxt_premium_status": premium_status
     ]
 

--- a/_safari/Save to Pocket Extension/Common/API.swift
+++ b/_safari/Save to Pocket Extension/Common/API.swift
@@ -160,6 +160,7 @@ class SaveToPocketAPI: SafariExtensionHandler{
     url: String,
     access_token: String,
     premium_status: String,
+    ui_context: String,
     completion: @escaping (Result<Any, RequestError>) -> Void
     ) -> Void {
 
@@ -168,7 +169,7 @@ class SaveToPocketAPI: SafariExtensionHandler{
     let saveAction: [String : Any] = [
       "action": "add",
       "url": url,
-      "cxt_ui": "toolbar",
+      "cxt_ui": ui_context,
       "cxt_premium_status": premium_status
     ]
 

--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -10,6 +10,7 @@ import SafariServices
 
 var postAuthSave:SFSafariPage? = nil
 var postAuthLink:String? = nil
+var postAuthContext:String? = "toolbar"
 
 class Actions {
 
@@ -67,7 +68,7 @@ class Actions {
               }
               else{
                 // Save the correct page
-                self.savePage(from: postAuthSave!)
+                self.savePage(from: postAuthSave!, ui_context: postAuthContext!)
               }
 
               // Since we got the Auth Code from the passed in page, we close that page
@@ -86,14 +87,15 @@ class Actions {
 
   }
 
-  static func saveFromContext(from page: SFSafariPage, userInfo: [String : Any]?, is_menu: Bool){
+  static func saveFromContext(from page: SFSafariPage, userInfo: [String : Any]?){
 
     let url = userInfo!["urlToSave"] as! String
     NSLog("Saving from context")
 
     if url == "page" {
       NSLog("Context without a link")
-      Actions.savePage(from: page, is_menu: is_menu)
+      postAuthContext = "right_click_page"
+      Actions.savePage(from: page, ui_context: "right_click_page")
       return
     }
 
@@ -101,7 +103,7 @@ class Actions {
     Actions.saveLink(from: page, url: url)
   }
 
-  static func savePage(from page: SFSafariPage, is_menu: Bool? = false){
+  static func savePage(from page: SFSafariPage, ui_context: String = "toolbar"){
 
     page.getPropertiesWithCompletionHandler { properties in
 
@@ -131,10 +133,6 @@ class Actions {
         userInfo: nil
       )
 
-        var ui_context = "toolbar"
-        if (is_menu ?? false) {
-            ui_context = "right_click_page"
-        }
         SaveToPocketAPI.saveToPocket(from: page, url: url, access_token: access_token, premium_status: premium_status, ui_context: ui_context) { result in
 
         switch result {
@@ -177,6 +175,7 @@ class Actions {
         // No auth token, need to log in
         postAuthSave = page
         postAuthLink = url
+        postAuthContext = "right_click_link"
         Actions.logIn(from: page)
         return
       }

--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -86,14 +86,14 @@ class Actions {
 
   }
 
-  static func saveFromContext(from page: SFSafariPage, userInfo: [String : Any]?){
+  static func saveFromContext(from page: SFSafariPage, userInfo: [String : Any]?, is_menu: Bool){
 
     let url = userInfo!["urlToSave"] as! String
     NSLog("Saving from context")
 
     if url == "page" {
       NSLog("Context without a link")
-      Actions.savePage(from: page)
+      Actions.savePage(from: page, is_menu: is_menu)
       return
     }
 
@@ -101,7 +101,7 @@ class Actions {
     Actions.saveLink(from: page, url: url)
   }
 
-  static func savePage(from page: SFSafariPage){
+  static func savePage(from page: SFSafariPage, is_menu: Bool? = false){
 
     page.getPropertiesWithCompletionHandler { properties in
 
@@ -131,8 +131,11 @@ class Actions {
         userInfo: nil
       )
 
-
-        SaveToPocketAPI.saveToPocket(from: page, url: url, access_token: access_token, premium_status: premium_status, ui_context: "right_click_page") { result in
+        var ui_context = "toolbar"
+        if (is_menu ?? false) {
+            ui_context = "right_click_page"
+        }
+        SaveToPocketAPI.saveToPocket(from: page, url: url, access_token: access_token, premium_status: premium_status, ui_context: ui_context) { result in
 
         switch result {
 

--- a/_safari/Save to Pocket Extension/Common/Actions.swift
+++ b/_safari/Save to Pocket Extension/Common/Actions.swift
@@ -132,7 +132,7 @@ class Actions {
       )
 
 
-        SaveToPocketAPI.saveToPocket(from: page, url: url, access_token: access_token, premium_status: premium_status) { result in
+        SaveToPocketAPI.saveToPocket(from: page, url: url, access_token: access_token, premium_status: premium_status, ui_context: "right_click_page") { result in
 
         switch result {
 
@@ -187,7 +187,7 @@ class Actions {
     )
 
 
-    SaveToPocketAPI.saveToPocket(from: page, url: url, access_token: access_token, premium_status: premium_status) { result in
+    SaveToPocketAPI.saveToPocket(from: page, url: url, access_token: access_token, premium_status: premium_status, ui_context: "right_click_link") { result in
 
       switch result {
 

--- a/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
+++ b/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
@@ -43,7 +43,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     case Receive.LOGGED_OUT_OF_POCKET:
       Actions.logOut(from: page)
       return
-      
+
     case Receive.SAVE_PAGE_TO_POCKET:
       Actions.savePage(from: page)
       return
@@ -85,7 +85,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
       NSLog("Save to pocket context with userInfo: \(String(describing: userInfo!))")
     }
 
-    Actions.saveFromContext(from: page, userInfo: userInfo)
+    Actions.saveFromContext(from: page, userInfo: userInfo, is_menu: true)
   }
 
   override func messageReceivedFromContainingApp(withName messageName: String, userInfo: [String : Any]? = nil) {

--- a/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
+++ b/_safari/Save to Pocket Extension/SafariExtensionHandler.swift
@@ -85,7 +85,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
       NSLog("Save to pocket context with userInfo: \(String(describing: userInfo!))")
     }
 
-    Actions.saveFromContext(from: page, userInfo: userInfo, is_menu: true)
+    Actions.saveFromContext(from: page, userInfo: userInfo)
   }
 
   override func messageReceivedFromContainingApp(withName messageName: String, userInfo: [String : Any]? = nil) {

--- a/src/containers/save/_save.js
+++ b/src/containers/save/_save.js
@@ -273,7 +273,7 @@ function buildSaveObject(action, setup) {
       const url = tab.url
       const title = tab.title
       const saveType = 'page'
-      const actionInfo = { cxt_ui: 'toolbar', cxt_premium_status }
+      const actionInfo = { cxt_ui: 'toolbar', cxt_premium_status, cxt_view: 'ext_popover' }
       const showSavedIcon = true
 
       return {
@@ -295,7 +295,7 @@ function buildSaveObject(action, setup) {
       const title = savedLink ? info.selectionText || info.linkUrl : tab.title
       const cxt_ui = savedLink ? 'right_click_link' : 'right_click_page'
       const saveType = savedLink ? 'link' : 'page'
-      const actionInfo = { cxt_ui, cxt_premium_status }
+      const actionInfo = { cxt_ui, cxt_premium_status, cxt_view: 'ext_popover' }
       const showSavedIcon = savedLink ? 0 : 1
 
       return {


### PR DESCRIPTION
## Goal

Fix analytics not passing all context cxt_ui parameters when saving from right click context menu.

The save from right clicking a page needs to pass
		```"cxt_ui": "right_click_page"```

The save from right clicking a link needs to pass
		```"cxt_ui": "right_click_link"```

The save from clicking the toolbar icon needs to pass
		```"cxt_ui": "toolbar"```

```
{
	"access_token": "61994fee-72de-6d59-3dd1-2d91cd",
	"actions": [{
		"url": "https:\/\/www.cnn.com\/us\/live-news\/texas-flooding-september-2019\/index.html",
		"action": "add",
		"cxt_ui": "right_click_page",
		"cxt_premium_status": "1"
	}],
	"consumer_key": "9346-1e342af73fe11d5174042e9d"
}

```

## Todos:
- [x] save link context
- [x] save page context
- [x] save toolbar context
- [x] add cxt_view to add action to ensure premium status is saved
- [x] go over solution w/ joel to refactor anything that may have been missed 
- [x] handle post auth use case to ensure that saves happening before auth also pass the right context params

## Implementation Decisions
Add new parameter for ui context to pass to save pocket function as well as pass boolean `is_menu` so that we can differentiate between right click page and toolbar click saves.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
