### PR TITLE
fix(safari): pass link on contained element click

### DIFF
--- a/src/containers/safari/dispatch.js
+++ b/src/containers/safari/dispatch.js
@@ -30,7 +30,8 @@ export const dispatchInit = () => {
 /* Handle incoming messages
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 function handleContextMenu(event) {
-  const link = event.target.href
+  const anchor = event.target.closest('a')
+  const link = anchor ? anchor.href : false
   const urlToSave = link ? link : 'page'
   safari.extension.setContextMenuEventUserInfo(event, { urlToSave })
 }


### PR DESCRIPTION
## Goal
Handle clicks on nested elements in an anchor properly.

## Todos:
- [x] Find closest anchor
- [x] Default to page

## Implementation Decisions
Using closest() since it is supported in Safari version we are targeting and several versions back.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
