### PR TITLE
fix(safari): reset tag state on save request

### DIFF
--- a/src/containers/safari/tags.state.js
+++ b/src/containers/safari/tags.state.js
@@ -2,6 +2,7 @@
 import { delay } from 'redux-saga'
 import { takeLatest, select } from 'redux-saga/effects'
 import { checkDuplicate } from 'common/helpers'
+import { SAVE_TO_POCKET_REQUEST } from './actions'
 import { SUGGESTED_TAGS_REQUEST } from './actions'
 import { SUGGESTED_TAGS_SUCCESS } from './actions'
 import { SUGGESTED_TAGS_FAILURE } from './actions'
@@ -36,6 +37,10 @@ export const tagsReducers = (state = initialState, action) => {
   switch (action.type) {
     case SUGGESTED_TAGS_FAILURE: {
       return { ...state, suggested: false }
+    }
+
+    case SAVE_TO_POCKET_REQUEST: {
+      return initialState
     }
 
     case SUGGESTED_TAGS_SUCCESS: {


### PR DESCRIPTION
## Goal
If a user saves multiple articles on the same page (via context), we should make sure no relic tag suggestions are shown

## Todos:
- [x] Clear tag state on save requests

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
