### PR TITLE
feat(safari): adjust signing identity 

### DIFF
--- a/_safari/Save to Pocket Extension/Info.plist
+++ b/_safari/Save to Pocket Extension/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>consumerKey</key>
-	<string>$(CONSUMER_KEY)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -21,17 +19,17 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSAllowsArbitraryLoads</key>
+	<true/>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.Safari.extension</string>
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).SafariExtensionHandler</string>
-		<key>SFSafariStyleSheet</key>
-		<array/>
 		<key>SFSafariContentScript</key>
 		<array>
 			<dict>
@@ -43,31 +41,33 @@
 				<string>safari.js</string>
 			</dict>
 			<dict>
-				<key>Script</key>
-				<string>login.js</string>
 				<key>Allowed URL Patterns</key>
 				<array>
 					<string>https://getpocket.com/extension_login_success</string>
 				</array>
+				<key>Script</key>
+				<string>login.js</string>
 			</dict>
 			<dict>
-				<key>Script</key>
-				<string>logout.js</string>
 				<key>Allowed URL Patterns</key>
 				<array>
 					<string>https://getpocket.com/login</string>
 				</array>
+				<key>Script</key>
+				<string>logout.js</string>
 			</dict>
 		</array>
 		<key>SFSafariContextMenu</key>
 		<array>
 			<dict>
-				<key>Text</key>
-				<string>Save to Pocket</string>
 				<key>Command</key>
 				<string>SAVE_TO_POCKET_CONTEXT</string>
+				<key>Text</key>
+				<string>Save to Pocket</string>
 			</dict>
 		</array>
+		<key>SFSafariStyleSheet</key>
+		<array/>
 		<key>SFSafariToolbarItem</key>
 		<dict>
 			<key>Action</key>
@@ -87,9 +87,9 @@
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2019 Pocket. All rights reserved.</string>
-	<key>NSAllowsArbitraryLoads</key>
-	<true/>
 	<key>NSHumanReadableDescription</key>
 	<string>Pocket’s Safari extension is the easiest, fastest way to capture articles, videos, and anything else you find online.</string>
+	<key>consumerKey</key>
+	<string>$(CONSUMER_KEY)</string>
 </dict>
 </plist>

--- a/_safari/Save to Pocket.xcodeproj/project.pbxproj
+++ b/_safari/Save to Pocket.xcodeproj/project.pbxproj
@@ -587,6 +587,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Save to Pocket Extension/Save to Pocket Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				INFOPLIST_FILE = "Save to Pocket Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -607,6 +608,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Save to Pocket Extension/Save to Pocket Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				INFOPLIST_FILE = "Save to Pocket Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -629,6 +631,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Save to Pocket/Save to Pocket.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				INFOPLIST_FILE = "Save to Pocket/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -649,6 +652,7 @@
 				CODE_SIGN_ENTITLEMENTS = "Save to Pocket/Save to Pocket.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = EX3VH4YFCH;
 				INFOPLIST_FILE = "Save to Pocket/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/_safari/Save to Pocket.xcodeproj/project.pbxproj
+++ b/_safari/Save to Pocket.xcodeproj/project.pbxproj
@@ -272,7 +272,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1020;
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1100;
 				ORGANIZATIONNAME = Pocket;
 				TargetAttributes = {
 					314EF96E2289D10200704C32 = {
@@ -586,6 +586,7 @@
 			baseConfigurationReference = 5DEBE81C2333359B002FF684 /* keys.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Save to Pocket Extension/Save to Pocket Extension.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = EX3VH4YFCH;
@@ -607,6 +608,7 @@
 			baseConfigurationReference = 5DEBE81C2333359B002FF684 /* keys.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Save to Pocket Extension/Save to Pocket Extension.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = EX3VH4YFCH;
@@ -629,6 +631,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Save to Pocket/Save to Pocket.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 3;
@@ -650,6 +653,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "Save to Pocket/Save to Pocket.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 3;

--- a/_safari/Save to Pocket/Base.lproj/Main.storyboard
+++ b/_safari/Save to Pocket/Base.lproj/Main.storyboard
@@ -160,6 +160,7 @@ check the box next to Pocket in your Safari preferences. </string>
                             <constraint firstItem="10f-Lu-W1H" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" id="fWb-PO-NhG"/>
                             <constraint firstItem="10f-Lu-W1H" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" id="gNg-bo-MVx"/>
                             <constraint firstItem="fNZ-Kz-7My" firstAttribute="leading" secondItem="X1M-w3-9da" secondAttribute="leading" id="jxp-mr-Mzf"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="KS5-nJ-s61" secondAttribute="trailing" id="kbq-WU-tKn"/>
                             <constraint firstAttribute="trailing" secondItem="10f-Lu-W1H" secondAttribute="trailing" id="m6i-Lb-4Wn"/>
                             <constraint firstItem="fNZ-Kz-7My" firstAttribute="top" secondItem="X1M-w3-9da" secondAttribute="bottom" constant="35" id="vP2-xb-dgv"/>
                             <constraint firstItem="fNZ-Kz-7My" firstAttribute="trailing" secondItem="X1M-w3-9da" secondAttribute="trailing" id="zxB-HK-AH3"/>

--- a/_safari/Save to Pocket/Info.plist
+++ b/_safari/Save to Pocket/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ATSApplicationFontsPath</key>
+	<string>fonts</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -19,7 +21,9 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.news</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSHumanReadableCopyright</key>
@@ -28,9 +32,5 @@
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>ATSApplicationFontsPath</key>
-	<string>fonts</string>
-	<key>LSApplicationCategoryType</key>
-	<string>public.app-category.news</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Goal

Make this work. 

## Todos:

- [x] Bump build number to 3 
- [x] Import app configuration from App Store connect

## Discussion

Before you do anything, let's validate that you can reproduce the problem. (Note: since I've fixed the signing identities on the server, it's possible that we won't be able to reproduce this problem anymore). 

Under `Window` ... `Organizer`, locate the version of the app that you submitted.

Select `Distribute App`

![Screen Shot 2019-09-21 at 10 49 03](https://user-images.githubusercontent.com/5227069/65377165-7dabef80-dc5d-11e9-8c08-0e0f5145fb73.jpg)

Select `Copy` ... save to desktop.

![Screen Shot 2019-09-21 at 10 49 17](https://user-images.githubusercontent.com/5227069/65377208-ed21df00-dc5d-11e9-87ca-c637dff2f0ca.jpg)

Try using the extension. For me, before generating a new signing identity, the launcher would work, but the extension button would not. 

Next, go to Xcode preferences ... `Accounts`

![Screen Shot 2019-09-21 at 10 47 54](https://user-images.githubusercontent.com/5227069/65377197-c794d580-dc5d-11e9-99a5-1971af543ddb.jpg)

Select `Download Manual Profiles`

Archive the app.

Assuming your previous `Export` failed, verify that this one doesn't. 

Assuming everything works as expected, `Distribute` the app as before. 


## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
