### PR TITLE
build(linting): adding pr title lint parameters

### DIFF
--- a/.github/prlint.json
+++ b/.github/prlint.json
@@ -1,0 +1,20 @@
+{
+  "title": [
+    {
+      "pattern": "^(build|ci|docs|feat|fix|project|refactor|ui|style|test|chore).{1,}",
+      "message": "Your title needs to be prefixed with on of the following types: build|ci|docs|feat|fix|project|refactor|ui|style|test|chore"
+    }
+  ],
+  "body": [
+    {
+      "pattern": ".{1,}",
+      "message": "You need literally anything in your description"
+    }
+  ],
+  "head.ref": [
+    {
+      "pattern": "^(build|ci|docs|feat|fix|perf|refactor|style|test|refactor|project|release)/",
+      "message": "Your branch name is invalid"
+    }
+  ]
+}


### PR DESCRIPTION
## Goal

Adding basic lint for branches/pr titles

## Implementation Decisions

This will help keep consistency throughout the repo.  These will match commit linting to be added in the future.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
