### PR TITLE
fix(tags): fix disappearing popup while updating tags on new website

### DIFF
--- a/src/containers/save/save.app.js
+++ b/src/containers/save/save.app.js
@@ -53,8 +53,9 @@ class App extends Component {
     return isActive
   }
 
-  setInputFocusState = bool => {
-    this.setState({ inputFocused: bool })
+  setInputFocusState = inputFocused => {
+    this.props.setTagInputFocus(inputFocused)
+    this.setState({ inputFocused })
   }
 
   get tabIsActive() {

--- a/src/containers/save/toolbar/tagging/_tagging.js
+++ b/src/containers/save/toolbar/tagging/_tagging.js
@@ -17,6 +17,9 @@ export const taggingActions = {
   addTag: tag => {
     return { type: 'TAG_ADD', tag }
   },
+  setTagInputFocus: tagInputFocus => {
+    return { type: 'TAG_INPUT_FOCUS', tagInputFocus }
+  },
   deactivateTags: data => {
     return { type: 'TAGS_DEACTIVATE', data }
   },
@@ -78,6 +81,11 @@ export const tags = (state = {}, action) => {
           used: [...usedTags, tagValue]
         }
       }
+    }
+
+    case 'TAG_INPUT_FOCUS': {
+      const { tagInputFocus } = action
+      return { ...state, tagInputFocus }
     }
 
     case 'TAG_REMOVE': {
@@ -174,6 +182,9 @@ export function* wSuggestedTags() {
 export function* wTagChanges() {
   yield takeLatest(['TAG_ADD', 'TAG_REMOVE', 'TAGS_REMOVE'], tagChanges)
 }
+export function* wTagInputFocus() {
+  yield takeLatest(['TAG_INPUT_FOCUS'], tagInputFocus)
+}
 
 const getUsedTags = state => {
   const activeTabId = state.active
@@ -189,6 +200,8 @@ const getUsedTags = state => {
     tabId: activeTabId
   }
 }
+
+const getTagInputFocus = state => state.tagInputFocused
 
 const getStoredTags = state => {
   return state.setup.tags_stored || []
@@ -232,4 +245,12 @@ function* tagChanges() {
   })
 
   yield call(API.syncItemTags, tagInfo.id, tagInfo.tags)
+}
+
+function* tagInputFocus() {
+  const focused = yield select(getTagInputFocus)
+
+  if(focused) {
+    yield put({ type: 'CANCEL_CLOSE_SAVE_PANEL' })
+  }
 }

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -1,5 +1,5 @@
 name: 'Save to Pocket'
-version: 3.0.6.8
+version: 3.0.7
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"

--- a/src/store/combineActions.js
+++ b/src/store/combineActions.js
@@ -23,6 +23,7 @@ const {
   activateTag,
   deactivateTag,
   addTag,
+  setTagInputFocus,
   removeTag,
   deactivateTags,
   removeTags
@@ -56,6 +57,7 @@ export {
   activateTag,
   deactivateTag,
   addTag,
+  setTagInputFocus,
   removeTag,
   deactivateTags,
   removeTags,

--- a/src/store/combineSagas.js
+++ b/src/store/combineSagas.js
@@ -21,7 +21,7 @@ import { wSaveUrl } from '../containers/save/_save'
 import { wRemoveItem } from '../containers/save/_save'
 import { wArchiveItem } from '../containers/save/_save'
 
-import { wTagChanges } from '../containers/save/toolbar/tagging/_tagging'
+import { wTagChanges, wTagInputFocus } from '../containers/save/toolbar/tagging/_tagging'
 import { wSuggestedTags } from '../containers/save/toolbar/tagging/_tagging'
 
 import { wRecommendations } from '../containers/save/recommendations/_recommendations'
@@ -69,6 +69,7 @@ export default function* rootSaga() {
     wArchiveItem(),
 
     wTagChanges(),
+    wTagInputFocus(),
     wSuggestedTags(),
 
     wRecommendations(),


### PR DESCRIPTION
## Goal

Fix #65: popup closes while typing tags

### Root cause
The root cause seems to be that upon tag input the cancel close request is not being called so once the timeout reaches the popup is closed even while the user is typing a tag.

## Todos:
- [x] Reproduce issue ( steps outlined in #65 )
- [x] add a tag input focus action whenever input receives focus
- [x] trigger cancel close request when input receives focus

## Implementation Decisions

### Approach
I decided to add a tag input focus action and saga that ensures cancel close request is explicitly triggered whenever the tag input receives focus.

## All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
