### PR TITLE
feat(recs): update recommendations endpoint to use recit

### DIFF
--- a/_chromium/manifest.yml
+++ b/_chromium/manifest.yml
@@ -1,5 +1,5 @@
 name: "Save to Pocket"
-version: 3.0.6.8
+version: 3.0.6.9
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"

--- a/_chromium/manifest.yml
+++ b/_chromium/manifest.yml
@@ -1,5 +1,5 @@
 name: "Save to Pocket"
-version: 3.0.6.9
+version: 3.1.0.0
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"

--- a/src/common/api/saving/recommendations.js
+++ b/src/common/api/saving/recommendations.js
@@ -6,14 +6,14 @@ import { getCurrentLanguageCode } from '../../helpers'
 export function getRecommendations(resolved_id) {
   var lang = getCurrentLanguageCode()
   return request({
-    path: 'v3/discover/recIt',
+    path: 'discover/recIt',
     data: {
       item_id: resolved_id,
       locale_lang: lang,
       count: 3,
       module: 'after_article_web'
     }
-  }).then(response => response)
+  }).then((response) => response)
 }
 
 export function saveRecToPocket(saveObject) {
@@ -36,7 +36,7 @@ export function saveRecToPocket(saveObject) {
         }
       ]
     }
-  }).then(response => {
+  }).then((response) => {
     return response
       ? { saveObject, status: 'ok', response: response.action_results[0] }
       : undefined
@@ -58,7 +58,7 @@ export function openRecommendation(saveObject) {
         }
       ]
     }
-  }).then(response => {
+  }).then((response) => {
     return response
       ? { saveObject, status: 'ok', response: response.action_results[0] }
       : undefined

--- a/src/common/api/saving/recommendations.js
+++ b/src/common/api/saving/recommendations.js
@@ -6,12 +6,12 @@ import { getCurrentLanguageCode } from '../../helpers'
 export function getRecommendations(resolved_id) {
   var lang = getCurrentLanguageCode()
   return request({
-    path: 'getSuggestedItems/',
+    path: 'v3/discover/recIt',
     data: {
-      resolved_id: resolved_id,
-      version: 2,
+      item_id: resolved_id,
       locale_lang: lang,
-      count: 3
+      count: 3,
+      module: 'after_article_web'
     }
   }).then(response => response)
 }

--- a/src/components/views/doorhanger/recommendations/list/item.js
+++ b/src/components/views/doorhanger/recommendations/list/item.js
@@ -119,6 +119,7 @@ export const SaveButton = styled.button`
   &:hover {
     border: 0;
     color: ${$hotCoral};
+    background-color: transparent;
   }
 `
 

--- a/src/components/views/doorhanger/recommendations/list/item.js
+++ b/src/components/views/doorhanger/recommendations/list/item.js
@@ -119,7 +119,6 @@ export const SaveButton = styled.button`
   &:hover {
     border: 0;
     color: ${$hotCoral};
-    background-color: transparent;
   }
 `
 

--- a/src/containers/recs.state.js
+++ b/src/containers/recs.state.js
@@ -33,10 +33,10 @@ export const recReducers = (state = initialState, action) => {
     }
 
     case GET_RECS_SUCCESS: {
-      const { feed, reason } = action.payload
+      const { recommendations, reason } = action.payload
       return {
         ...state,
-        feed: buildFeed(feed, action.source_id),
+        feed: buildFeed(recommendations, action.source_id),
         reason
       }
     }


### PR DESCRIPTION
## Goal
Get recommendations from RecIt. Recommendations should be better, and it would allow us to remove the fragile /recs endpoint from feed-machine that is currently serving recommendations to Chrome.

## Todos:
- [ ] QA

## Implementation Decisions


## All Submissions:

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
