### PR TITLE
fix(recs): update recs request with correct module and only fetch when resolved id exists

### DIFF
--- a/_chromium/handlersPostSave.js
+++ b/_chromium/handlersPostSave.js
@@ -29,7 +29,7 @@ export async function saveSuccess(tabId, payload) {
   getTagSuggestions(url, tabId)
 
   // Request recommendations or survey ?? For future
-  getItemRecommendations(resolved_id, tabId)
+  if (resolved_id) getItemRecommendations(resolved_id, tabId)
 }
 
 /* Get stored tags

--- a/_chromium/manifest.yml
+++ b/_chromium/manifest.yml
@@ -1,5 +1,5 @@
 name: "Save to Pocket"
-version: 3.1.0.1
+version: 3.1.0.2
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"

--- a/_chromium/manifest.yml
+++ b/_chromium/manifest.yml
@@ -1,5 +1,5 @@
 name: "Save to Pocket"
-version: 3.1.0.2
+version: 3.1.1.0
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"

--- a/src/common/api/saving/recommendations.js
+++ b/src/common/api/saving/recommendations.js
@@ -11,7 +11,7 @@ export function getRecommendations(resolved_id) {
       item_id: resolved_id,
       locale_lang: lang,
       count: 3,
-      module: 'after_article_web'
+      module: 'chrome_plugin'
     }
   }).then((response) => response)
 }


### PR DESCRIPTION
Could we swap this to use its own endpoint so it doesn't accidentally get impacted by changes to other endpoint? There isn't a `web_after_article` module right now, so this isn't a huge deal, but better if we can get it right now.

@mmiermans can you confirm the backend is fine with passing arbitrary modules to RecIt?