### PR TITLE
fix(inject): do not inject html elements until user saves page [FRONT-762]

### DIFF
--- a/_chromium/manifest.yml
+++ b/_chromium/manifest.yml
@@ -1,5 +1,5 @@
 name: "Save to Pocket"
-version: 3.1.1.0
+version: 3.1.2.0
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"

--- a/src/containers/inject.js
+++ b/src/containers/inject.js
@@ -39,7 +39,6 @@ export function injectDomElements() {
   if (window.top === window) {
     function setLoaded() {
       dispatchInit()
-      injectDomElements()
     }
 
     // Check page has loaded and if not add listener for it


### PR DESCRIPTION
## Goal

We received user reports that the HTML elements for the pocket dropdown were being included on every page before a user had saved the page. This was adding unnecessary clutter to the dom. 

## Todos:
- [x] Remove `injectDomElements` call from initial page load
- [x] Bumped manifest

## Implementation Decisions

We were attempting to inject the elements into the dom twice; once on page load, and once when a user saved the page. I removed the call to the inject script from page load.

The call on page save is here:
https://github.com/Pocket/extension-save-to-pocket/blob/master/src/containers/dispatch.js#L70