### PR TITLE
fix(recommendations): add utm_source query param

### DIFF
--- a/_chromium/manifest.yml
+++ b/_chromium/manifest.yml
@@ -1,5 +1,5 @@
 name: "Save to Pocket"
-version: 3.1.2.0
+version: 3.1.3.0
 options_page: options.html
 description: __MSG_extDescriptionGoogleChrome__
 default_locale: "en"

--- a/src/components/views/doorhanger/recommendations/list/item.js
+++ b/src/components/views/doorhanger/recommendations/list/item.js
@@ -150,6 +150,10 @@ export default function RecommendationItem({
     })
   }
 
+  // Append UTM to rec URLs (leave existing query strings intact)
+  const querySeparator = item.url.match(/\?/) ? '&' : '?'
+  const hrefUrl = `${item.url}${querySeparator}utm_source=pocket-chrome-recs`
+
   return (
     <ItemContainer hasImage={item.has_image}>
       {item.has_image && <ItemImage style={imageStyle} />}
@@ -157,7 +161,7 @@ export default function RecommendationItem({
       <ItemTitle>
         <ItemLink
           onClick={onClick}
-          href={item.url}
+          href={hrefUrl}
           rel="noopener noreferrer"
           target="_blank">
           {item.title}


### PR DESCRIPTION
## Goal

Add UTM tracking to the recs we serve in the Chrome Extension. This would help us see how much traffic those recs are driving to syndicated content, and also allow our publisher partners to more holistically see how much traffic Pocket drives to their sites.

## Todos:
- [x] Add query param

## Implementation Decisions

I was not able to confirm whether recommendations are passed to the extension with any existing query params in place, so this solution handles both instances of urls with and without.