### PR TITLE
fix(options): await getSetting calls as they are async

### DIFF
--- a/src/pages/options/options.js
+++ b/src/pages/options/options.js
@@ -193,7 +193,7 @@ const OptionsApp = () => {
     setDarkMode(getBool(await getSetting('dark_mode')))
     setAccessToken(await getSetting('access_token'))
     setUserName(await getSetting('username'))
-  })
+  }, [])
 
   const toggleTwitter = () => {
     setSitesTwitter(!sitesTwitter)

--- a/src/pages/options/options.js
+++ b/src/pages/options/options.js
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { css, cx } from 'linaria'
 import Toggle from '../../components/toggle/toggle'
 import { getBool } from 'common/utilities'
@@ -183,10 +183,17 @@ const optionsFooter = css`
 `
 
 const OptionsApp = () => {
-  const [sitesTwitter, setSitesTwitter] = useState(getBool(getSetting('sites_twitter')))
-  const [darkMode] = useState(getBool(getSetting('darkMode')))
-  // const [accessToken] = useState(getSetting('access_token'))
-  // const [userName] = useState(getSetting('username'))
+  const [sitesTwitter, setSitesTwitter] = useState()
+  const [darkMode, setDarkMode] = useState()
+  const [accessToken, setAccessToken] = useState()
+  const [userName, setUserName] = useState()
+
+  useEffect( async ()=>{
+    setSitesTwitter(getBool(await getSetting("sites_twitter")))
+    setDarkMode(getBool(await getSetting("dark_mode")))
+    setAccessToken(await getSetting("access_token"))
+    setUserName(await getSetting("username"))
+  })
 
   const toggleTwitter = () => {
     setSitesTwitter(!sitesTwitter)
@@ -211,8 +218,7 @@ const OptionsApp = () => {
             {localize('options_page', 'login_title')}
           </div>
           <div className={cx(optionsSectionMain, darkMode ? 'darkMode' : null)}>
-            TODO: fix accessToken & userName stuff here
-            {/* {(accessToken && userName) ? (
+            {(accessToken && userName) ? (
               <div>
                 {userName} &nbsp; ({' '}
                 <button className={optionsButtonLink} onClick={logoutAction}>
@@ -223,7 +229,7 @@ const OptionsApp = () => {
               <button className={optionsButtonLink} onClick={loginAction}>
                 {localize('options_page', 'login_link')}
               </button>
-            )} */}
+            )}
           </div>
         </div>
       </div>

--- a/src/pages/options/options.js
+++ b/src/pages/options/options.js
@@ -189,10 +189,10 @@ const OptionsApp = () => {
   const [userName, setUserName] = useState()
 
   useEffect( async ()=>{
-    setSitesTwitter(getBool(await getSetting("sites_twitter")))
-    setDarkMode(getBool(await getSetting("dark_mode")))
-    setAccessToken(await getSetting("access_token"))
-    setUserName(await getSetting("username"))
+    setSitesTwitter(getBool(await getSetting('sites_twitter')))
+    setDarkMode(getBool(await getSetting('dark_mode')))
+    setAccessToken(await getSetting('access_token'))
+    setUserName(await getSetting('username'))
   })
 
   const toggleTwitter = () => {
@@ -274,17 +274,17 @@ const OptionsApp = () => {
           <div className={cx(optionsSectionMain, darkMode ? 'darkMode' : null)}>
             <ul className={optionsQuestionsList}>
               <li>
-                <a href="https://help.getpocket.com">
+                <a href='https://help.getpocket.com'>
                   {localize('options_page', 'search_support_link')}
                 </a>
               </li>
               <li>
-                <a href="https://getpocket.com/extension/support">
+                <a href='https://getpocket.com/extension/support'>
                   {localize('options_page', 'send_us_an_email_link')}
                 </a>
               </li>
               <li>
-                <a href="https://twitter.com/intent/tweet?screen_name=pocketsupport&text=%23chrome">
+                <a href='https://twitter.com/intent/tweet?screen_name=pocketsupport&text=%23chrome'>
                   {localize('options_page', 'get_in_touch_on_twitter_link')}
                 </a>
               </li>
@@ -301,36 +301,36 @@ const OptionsApp = () => {
           <div className={cx(optionsSectionMain, darkMode ? 'darkMode' : null)}>
             <a
               className={optionsContentFullBlock}
-              href="https://chrome.google.com/webstore/detail/pocket-new-tab/mlnnopicjonfamklpcdfnbcomdlopmof?authuser=1"
-              rel="noopener noreferrer"
-              target="_blank">
+              href='https://chrome.google.com/webstore/detail/pocket-new-tab/mlnnopicjonfamklpcdfnbcomdlopmof?authuser=1'
+              rel='noopener noreferrer'
+              target='_blank'>
               <div className={optionsBlockCopy}>
                 Pocket New Tab
               </div>
             </a>
             <a
               className={optionsContentFullBlock}
-              href="http://getpocket.com/android/"
-              rel="noopener noreferrer"
-              target="_blank">
+              href='http://getpocket.com/android/'
+              rel='noopener noreferrer'
+              target='_blank'>
               <div className={optionsBlockCopy}>
                 Android
               </div>
             </a>
             <a
               className={optionsContentFullBlock}
-              href="http://getpocket.com/iphone/"
-              rel="noopener noreferrer"
-              target="_blank">
+              href='http://getpocket.com/iphone/'
+              rel='noopener noreferrer'
+              target='_blank'>
               <div className={optionsBlockCopy}>
                 iPhone/iPad
               </div>
             </a>
             <a
               className={optionsContentFullBlock}
-              href="http://getpocket.com/mac/"
-              rel="noopener noreferrer"
-              target="_blank">
+              href='http://getpocket.com/mac/'
+              rel='noopener noreferrer'
+              target='_blank'>
               <div className={optionsBlockCopy}>
                 Mac
               </div>
@@ -344,9 +344,9 @@ const OptionsApp = () => {
         &copy; Copyright {new Date().getFullYear()} Read It Later Inc.
         <a
           className={optionsPrivacyLegal}
-          href="https://getpocket.com/legal?src=extensions"
-          rel="noopener noreferrer"
-          target="_blank">
+          href='https://getpocket.com/legal?src=extensions'
+          rel='noopener noreferrer'
+          target='_blank'>
           Legal &amp; Privacy
         </a>
       </footer>


### PR DESCRIPTION
## Goal

Fix login/logout section not rendering in options page due to async `getSettings` calls
Remove double quotes

<img width="686" alt="Screen Shot 2021-09-28 at 5 01 28 PM" src="https://user-images.githubusercontent.com/2893463/135171772-4b63cff7-a718-4373-8473-af456a642d8f.png">

