### PR TITLE
fix(tags): force fetching of complete tags list

### DIFF
--- a/src/common/api/saving/tags.js
+++ b/src/common/api/saving/tags.js
@@ -31,6 +31,7 @@ export function fetchStoredTags(since) {
     data: {
       tags: 1,
       taglist: 1,
+      forcetaglist: 1,
       account: 1,
       since: since ? since : 0
     }


### PR DESCRIPTION
## Goal

The tags endpoint needs to be forced to make sure it delivers the newest updates.

## Todos:
- [x] Add `forcetaglist` param to tags query

## Implementation Decisions
This matches the behavior to how this endpoint is used in the web application