### PR TITLE
fix(context-menu): add log in to context menu and have it be account aware

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,6 +45,7 @@ export default {
     replace({
       preventAssignment: true,
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+      'process.env.IS_RELEASE': JSON.stringify(process.env.IS_RELEASE)
     }),
     replace({
       preventAssignment: false,

--- a/src/pages/background/index.js
+++ b/src/pages/background/index.js
@@ -1,6 +1,5 @@
 import * as handle from './userActions'
 import { setDefaultIcon } from 'common/interface'
-import { localize } from 'common/_locales/locales'
 
 import { AUTH_CODE_RECEIVED } from 'actions'
 import { USER_LOG_IN } from 'actions'
@@ -19,30 +18,7 @@ chrome.runtime.onInstalled.addListener(function () {
   // Use SVG icons over the png for more control
   setDefaultIcon()
 
-  chrome.contextMenus.create({
-    title: localize('context_menu', 'open_list'),
-    id: 'toolbarContextClickList',
-    contexts: ['action'],
-  })
-
-  chrome.contextMenus.create({
-    title: localize('context_menu', 'discover_more'),
-    id: 'toolbarContextClickHome',
-    contexts: ['action'],
-  })
-
-  chrome.contextMenus.create({
-    title: localize('context_menu', 'log_out'),
-    id: 'toolbarContextClickLogOut',
-    contexts: ['action'],
-  })
-
-  // Page Context - Right click menu on page
-  chrome.contextMenus.create({
-    title: localize('context_menu', 'save'),
-    id: 'pageContextClick',
-    contexts: ['page', 'frame', 'editable', 'image', 'video', 'audio', 'link', 'selection'], // prettier-ignore
-  })
+  handle.setContextMenus()
 })
 
 /* Browser Action - Toolbar

--- a/src/pages/injector/app.js
+++ b/src/pages/injector/app.js
@@ -8,6 +8,7 @@ import { FooterConnector } from 'connectors/footer/footer'
 import { getSetting } from 'common/interface'
 import { getOSModeClass } from 'common/helpers'
 import { GlobalVariables } from './globalStyles'
+import { getBool } from 'common/utilities'
 
 import { SAVE_TO_POCKET_REQUEST } from 'actions'
 import { SAVE_TO_POCKET_SUCCESS } from 'actions'
@@ -22,6 +23,8 @@ import { TAG_SYNC_SUCCESS } from 'actions'
 import { TAG_SYNC_FAILURE } from 'actions'
 import { UPDATE_TAG_ERROR } from 'actions'
 
+const IS_RELEASE = getBool(process.env.IS_RELEASE)
+
 export const App = () => {
   const appTarget = useRef(null)
   const [saveStatus, setSaveStatus] = useState('saving')
@@ -33,9 +36,11 @@ export const App = () => {
   const handleMessages = (event) => {
     const { payload, action = 'Unknown Action' } = event || {}
 
-    console.groupCollapsed(`RECEIVE: ${action}`)
-    console.log(payload)
-    console.groupEnd(`RECEIVE: ${action}`)
+    if (!IS_RELEASE) {
+      console.groupCollapsed(`RECEIVE: ${action}`)
+      console.log(payload)
+      console.groupEnd(`RECEIVE: ${action}`)
+    }
 
     switch (action) {
       case SAVE_TO_POCKET_REQUEST: {


### PR DESCRIPTION
## Goal

The Pocket browser context menu should display "log in" or "log out" depending on stored `access_token`

## Todos:
- [x] Add Log In context menu
- [x] BONUS: Have console log for chrome actions only log for `npm run build` and not `npm run release`

## Implementation Decisions
Added a function for the sole purpose of clearing all context menu items, and then adding them back with a check for the `access_token`. 

Bonus addition that stops logging out all actions from `app.js` for production releases.