### PR TITLE
fix(login): adding wildcard to extension login success url

### DIFF
--- a/src/common/helpers.js
+++ b/src/common/helpers.js
@@ -47,7 +47,7 @@ export function checkDuplicate(list, tagValue) {
 
 export function closeLoginPage() {
   chrome.tabs.query(
-    { url: '*://getpocket.com/extension_login_success' },
+    { url: '*://getpocket.com/extension_login_success*' },
     (tabs) => {
       chrome.tabs.remove(tabs.map((tab) => tab.id))
     },


### PR DESCRIPTION
## Goal

Mini ran into an issue where the login redirect page wasn't closing automatically and I determined this was due to a query param being added to the url. Adding a wildcard to the end should fix it.

## Todos:
- [x] Add wildcard to end of redirect url path