### PR TITLE
fix(styling): style overrides and specificity

### DIFF
--- a/src/components/button/extensions-button.js
+++ b/src/components/button/extensions-button.js
@@ -12,6 +12,7 @@ const buttonStyles = css`
   padding: 8px 12px;
   transition: all 0.15s ease-out;
   text-decoration: none;
+  text-transform: none;
   cursor: pointer;
 
   &.disabled {

--- a/src/components/item-preview/item-preview.js
+++ b/src/components/item-preview/item-preview.js
@@ -34,6 +34,7 @@ const previewWrapper = css`
 
   p {
     margin: 0;
+    padding: 0;
     font-size: 14px;
     font-family: var(--fontSansSerif);
     color: var(--color-textPrimary);

--- a/src/pages/injector/app.js
+++ b/src/pages/injector/app.js
@@ -119,7 +119,7 @@ export const App = () => {
   const isRemoved = saveStatus === 'removed'
 
   return (
-    <div ref={appTarget} className={cx(globalReset, globalVariables, theme)}>
+    <div ref={appTarget} className={cx('pocket-extension', globalReset, globalVariables, theme)}>
       <Doorhanger isOpen={isOpen}>
         <HeadingConnector saveStatus={saveStatus} />
         {!isRemoved ? <ItemPreviewConnector /> : null}

--- a/src/pages/injector/globalStyles.js
+++ b/src/pages/injector/globalStyles.js
@@ -1,8 +1,7 @@
- import { css } from 'linaria'
+import { css } from 'linaria'
 
- export const globalReset = css`
-   :global() {
-
+export const globalReset = css`
+  :global() {
     header, footer, section, div, span, aside,
     h1, h2, h3, h4, h5, h6, p, a,
     button, form, input, label,
@@ -14,97 +13,104 @@
       font: inherit;
       vertical-align: baseline;
     }
-  }
- `
 
- export const globalVariables = css`
-   :global() {
-     .pocket-theme-light {
-       --color-canvas: #FFFFFF;
-       --color-textPrimary: #1A1A1A;
-       --color-textSecondary: #666666;
-       --color-actionPrimary: #008078;
-       --color-actionPrimaryHover: #004D48;
-       --color-actionPrimarySubdued: #E8F7F6;
-       --color-actionPrimaryText: #FFFFFF;
-       --color-actionSecondary: #1A1A1A;
-       --color-actionSecondaryHover: #1A1A1A;
-       --color-actionSecondaryHoverText: #F2F2F2;
-       --color-actionSecondaryText: #1A1A1A;
-       --color-actionBrand: #EF4056;
-       --color-actionFocus: #009990;
-       --color-formFieldFocusLabel: #008078;
-       --color-formFieldBorder: #8C8C8C;
-       --color-formFieldBorderHover: #333333;
-       --color-error: #B24000;
-       --color-dividerPrimary: #333333;
-       --color-dividerTertiary: #D9D9D9;
-       --color-calloutBackgroundPrimary: #E8F7F6;
-       --color-inlineButton: #008078;
-       --color-inlineButtonHover: #008078;
-       --color-headingBackground: #E8F7F6;
-       --color-headingErrorBackground: #FDF2F5;
-       --color-headingIcon: #EF4056;
-       --color-chipsBackground: #E8F7F6;
-       --color-chipsText: #004D48;
-       --color-chipsActive: #1A1A1A;
-       --color-taggingBorder: #D9D9D9;
-       --color-taggingShadow: rgba(0, 0, 0, 0.25);
-       --color-itemPreviewBackground: #F2F2F2;
-     }
+    .pocket-extension {
+      *:after,
+      *:before {
+        all: unset;
+      }
+    }
+  }
+`
+
+export const globalVariables = css`
+  :global() {
+    .pocket-theme-light {
+      --color-canvas: #FFFFFF;
+      --color-textPrimary: #1A1A1A;
+      --color-textSecondary: #666666;
+      --color-actionPrimary: #008078;
+      --color-actionPrimaryHover: #004D48;
+      --color-actionPrimarySubdued: #E8F7F6;
+      --color-actionPrimaryText: #FFFFFF;
+      --color-actionSecondary: #1A1A1A;
+      --color-actionSecondaryHover: #1A1A1A;
+      --color-actionSecondaryHoverText: #F2F2F2;
+      --color-actionSecondaryText: #1A1A1A;
+      --color-actionBrand: #EF4056;
+      --color-actionFocus: #009990;
+      --color-formFieldFocusLabel: #008078;
+      --color-formFieldBorder: #8C8C8C;
+      --color-formFieldBorderHover: #333333;
+      --color-error: #B24000;
+      --color-dividerPrimary: #333333;
+      --color-dividerTertiary: #D9D9D9;
+      --color-calloutBackgroundPrimary: #E8F7F6;
+      --color-inlineButton: #008078;
+      --color-inlineButtonHover: #008078;
+      --color-headingBackground: #E8F7F6;
+      --color-headingErrorBackground: #FDF2F5;
+      --color-headingIcon: #EF4056;
+      --color-chipsBackground: #E8F7F6;
+      --color-chipsText: #004D48;
+      --color-chipsActive: #1A1A1A;
+      --color-taggingBorder: #D9D9D9;
+      --color-taggingShadow: rgba(0, 0, 0, 0.25);
+      --color-itemPreviewBackground: #F2F2F2;
+    }
  
-     .pocket-theme-dark {
-       --color-canvas: #1A1A1A;
-       --color-textPrimary: #F2F2F2;
-       --color-textSecondary: #8C8C8C;
-       --color-actionPrimary: #008078;
-       --color-actionPrimaryHover: #004D48;
-       --color-actionPrimarySubdued: #00403C;
-       --color-actionPrimaryText: #FFFFFF;
-       --color-actionSecondary: #F2F2F2;
-       --color-actionSecondaryHover: #F2F2F2;
-       --color-actionSecondaryHoverText: #1A1A1A;
-       --color-actionSecondaryText: #F2F2F2;
-       --color-actionBrand: #EF4056;
-       --color-actionFocus: #00CCC0;
-       --color-formFieldFocusLabel: #00A69C;
-       --color-formFieldBorder: #737373;
-       --color-formFieldBorderHover: #CCCCCC;
-       --color-error: #E55300;
-       --color-dividerPrimary: #CCCCCC;
-       --color-dividerTertiary: #404040;
-       --color-calloutBackgroundPrimary: #004D48;
-       --color-inlineButton: #E8F7F6;
-       --color-inlineButtonHover: #E8F7F6;
-       --color-headingBackground: #404040;
-       --color-headingErrorBackground: #901424;
-       --color-headingIcon: #FDF2F5;
-       --color-chipsBackground: #004D48;
-       --color-chipsText: #ffffff;
-       --color-chipsActive: #ffffff;
-       --color-taggingBorder: #8C8C8C;
-       --color-taggingShadow: rgba(255, 255, 255, 0.25);
-       --color-itemPreviewBackground: #404040;
-     }
+    .pocket-theme-dark {
+      --color-canvas: #1A1A1A;
+      --color-textPrimary: #F2F2F2;
+      --color-textSecondary: #8C8C8C;
+      --color-actionPrimary: #008078;
+      --color-actionPrimaryHover: #004D48;
+      --color-actionPrimarySubdued: #00403C;
+      --color-actionPrimaryText: #FFFFFF;
+      --color-actionSecondary: #F2F2F2;
+      --color-actionSecondaryHover: #F2F2F2;
+      --color-actionSecondaryHoverText: #1A1A1A;
+      --color-actionSecondaryText: #F2F2F2;
+      --color-actionBrand: #EF4056;
+      --color-actionFocus: #00CCC0;
+      --color-formFieldFocusLabel: #00A69C;
+      --color-formFieldBorder: #737373;
+      --color-formFieldBorderHover: #CCCCCC;
+      --color-error: #E55300;
+      --color-dividerPrimary: #CCCCCC;
+      --color-dividerTertiary: #404040;
+      --color-calloutBackgroundPrimary: #004D48;
+      --color-inlineButton: #E8F7F6;
+      --color-inlineButtonHover: #E8F7F6;
+      --color-headingBackground: #404040;
+      --color-headingErrorBackground: #901424;
+      --color-headingIcon: #FDF2F5;
+      --color-chipsBackground: #004D48;
+      --color-chipsText: #ffffff;
+      --color-chipsActive: #ffffff;
+      --color-taggingBorder: #8C8C8C;
+      --color-taggingShadow: rgba(255, 255, 255, 0.25);
+      --color-itemPreviewBackground: #404040;
+    }
  
-   :root{
-     --color-white100: #FFFFFF;
-     --color-grey10: #1A1A1A;
-     --color-grey20: #333333;
-     --color-grey25: #404040;
-     --color-grey30: #4D4D4D;
-     --color-grey35: #595959;
-     --color-grey40: #666666;
-     --color-grey45: #737373;
-     --color-grey55: #8C8C8C;
-     --color-grey65: #A6A6A6;
-     --color-grey80: #CCCCCC;
-     --color-grey85: #D9D9D9;
-     --color-grey95: #F2F2F2;
-     --color-coral: #EF4056;
-     --color-amber: #FCB643;
-     --color-brandPocket: #EF4056;
-     --fontSansSerif: "Graphik Web", "Helvetica Neue", Helvetica, Arial, Sans-Serif;
+    :root {
+      --color-white100: #FFFFFF;
+      --color-grey10: #1A1A1A;
+      --color-grey20: #333333;
+      --color-grey25: #404040;
+      --color-grey30: #4D4D4D;
+      --color-grey35: #595959;
+      --color-grey40: #666666;
+      --color-grey45: #737373;
+      --color-grey55: #8C8C8C;
+      --color-grey65: #A6A6A6;
+      --color-grey80: #CCCCCC;
+      --color-grey85: #D9D9D9;
+      --color-grey95: #F2F2F2;
+      --color-coral: #EF4056;
+      --color-amber: #FCB643;
+      --color-brandPocket: #EF4056;
+      --fontSansSerif: "Graphik Web", "Helvetica Neue", Helvetica, Arial, Sans-Serif;
     }
   }
 `

--- a/src/pages/injector/globalStyles.js
+++ b/src/pages/injector/globalStyles.js
@@ -14,6 +14,10 @@ export const globalReset = css`
       vertical-align: baseline;
     }
 
+    // additional class here for when we need more
+    // specificity to override page styles, but also
+    // so we don't have to duplicate overrides to both 
+    // light & dark theme classes
     .pocket-extension {
       *:after,
       *:before {


### PR DESCRIPTION
## Todos:
- [x] Set `text-transform: none` on `Button`
- [x] Remove padding on `p` tags
- [x] Add additional class to `app.js` to be used for extra specificity when needing to override page styles


Before:
<img width="464" alt="Screen Shot 2021-10-19 at 12 20 59 PM" src="https://user-images.githubusercontent.com/2893463/137986333-20859e2d-47fe-402c-af3b-40a0800dd17c.png">

After:
<img width="530" alt="Screen Shot 2021-10-19 at 3 27 44 PM" src="https://user-images.githubusercontent.com/2893463/137986350-b345714f-3aeb-4f77-859e-ce8bf14ea4bc.png">