### PR TITLE
fix(css): scope css color variables to pocket extension class name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "save-to-pocket",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "private": true,
   "description": "The easiest, fastest way to capture articles, videos, and more.",
   "homepage": "https://github.com/Pocket/extension-save-to-pocket#readme",

--- a/src/components/button/extensions-button.js
+++ b/src/components/button/extensions-button.js
@@ -2,7 +2,8 @@ import React from 'react'
 import { css, cx } from 'linaria'
 
 const buttonStyles = css`
-  &.button {
+  &.pocket-button {
+    height: unset;
     display: inline-block;
     position: relative;
     font-family: var(--fontSansSerif);
@@ -107,7 +108,7 @@ const buttonStyles = css`
 
 export const Button = ({children, onClick, type = 'primary', className}) => {
   return (
-    <button className={cx('button', buttonStyles, type, className)} onClick={onClick}>
+    <button className={cx('pocket-button', buttonStyles, type, className)} onClick={onClick}>
       {children}
     </button>
   )

--- a/src/components/doorhanger/doorhanger.js
+++ b/src/components/doorhanger/doorhanger.js
@@ -5,7 +5,7 @@ const doorhangerStyle = css`
   position: fixed;
   top: 0;
   right: 0;
-  z-index: 9999;
+  z-index: 2147483647; // highest z-index possible
   font-family: var(--fontSansSerif);
 
   .doorHanger {

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -5,7 +5,7 @@ import { ListViewIcon } from 'components/icons/icons'
 import { Button } from 'components/button/extensions-button'
 
 const footerWrapper = css`
-  &.footer {
+  .pocket-extension &.footer {
     background-color: var(--color-canvas);
     display: flex;
     justify-content: space-between;
@@ -19,6 +19,11 @@ const footerWrapper = css`
     height: 25px;
     width: 25px;
     margin-right: 8px;
+
+    svg {
+      height: 25px;
+      width: 25px;
+    }
   }
 
   .buttonLink {

--- a/src/components/heading/heading.js
+++ b/src/components/heading/heading.js
@@ -6,7 +6,7 @@ import { ErrorIcon } from 'components/icons/icons'
 import { Button } from 'components/button/extensions-button'
 
 const headingStyle = css`
-  &.header {
+  .pocket-extension &.header {
     display: flex;
     justify-content: space-between;
     background-color: var(--color-headingBackground);
@@ -15,7 +15,7 @@ const headingStyle = css`
     font-size: 16px;
   }
 
-  .status {
+  .save-status {
     display: flex;
   }
 
@@ -32,6 +32,11 @@ const headingStyle = css`
     height: 25px;
     width: 25px;
     margin-top: 0;
+
+    svg {
+      height: 25px;
+      width: 25px;
+    }
   }
 
   .saveBlock {
@@ -69,7 +74,7 @@ export const Heading = ({ saveStatus, removeAction, saveAction }) => {
 
   return (
     <header className={cx('header', headingStyle, hasError && 'error')}>
-      <div className="status">
+      <div className="save-status">
         <div className="icon-wrapper">
           { isLoading ? <Loading /> : null }
           { hasError ? <ErrorIcon /> : null }

--- a/src/components/tagging/tagging.js
+++ b/src/components/tagging/tagging.js
@@ -77,9 +77,13 @@ const taggingWrapper = css`
     text-transform: lowercase;
     transform: translateZ(0.1);
 
-    .active &, &:hover {
+    &:hover {
       border: 1px solid var(--color-chipsActive);
     }
+  }
+
+  .tag-active .typeahead-item {
+    border: 1px solid var(--color-chipsActive);
   }
 `
 
@@ -221,7 +225,7 @@ export const Tagging = ({
                 <div className="typeahead-list">
                   {storedTagsList().map((item, index) => (
                     <div
-                      className={cx(highlightedIndex === index && 'active')}
+                      className={cx(highlightedIndex === index && 'tag-active')}
                       key={`item-${index}`}
                       {...getItemProps({ item, index})}
                     >

--- a/src/components/tagging/taginput/taginput.js
+++ b/src/components/tagging/taginput/taginput.js
@@ -8,20 +8,20 @@ const inputWrapper = css`
     max-width: 100%;
     display: inline-block;
     margin: 4px 0;
-  }
 
-  input {
-    all: unset;
-    color: var(--color-textPrimary);
-    font-family: var(--fontSansSerif);
-    display: inline-block;
-    line-height: 16px;
-    margin-bottom: 3px;
-    margin-left: 0;
-    margin-right: 3px;
-    margin-top: 3px;
-    min-width: 0.3em;
-    padding: 2px 4px;
+    input {
+      all: unset;
+      color: var(--color-textPrimary);
+      font-family: var(--fontSansSerif);
+      display: inline-block;
+      line-height: 16px;
+      margin-bottom: 3px;
+      margin-left: 0;
+      margin-right: 3px;
+      margin-top: 3px;
+      min-width: 0.3em;
+      padding: 2px 4px;
+    }
   }
 
   &.error input {

--- a/src/pages/injector/globalStyles.js
+++ b/src/pages/injector/globalStyles.js
@@ -8,7 +8,9 @@ export const globalReset = css`
   &.pocket-extension,
   .pocket-extension {
     *:after,
-    *:before {
+    *:before,
+    header,
+    footer {
       all: unset;
     }
   }

--- a/src/pages/injector/globalStyles.js
+++ b/src/pages/injector/globalStyles.js
@@ -1,28 +1,15 @@
 import { css } from 'linaria'
 
 export const globalReset = css`
-  :global() {
-    // additional class here for when we need more
-    // specificity to override page styles, but also
-    // so we don't have to duplicate overrides to both
-    // light & dark theme classes
-    .pocket-extension {
-      header, footer, section, div, span, aside,
-      h1, h2, h3, h4, h5, h6, p, a,
-      button, form, input, label,
-      img, ul, ol, li {
-        margin: 0;
-        padding: 0;
-        border: 0;
-        font-size: 100%;
-        font: inherit;
-        font-family: var(--fontSansSerif);
-      }
-
-      *:after,
-      *:before {
-        all: unset;
-      }
+  // additional class here for when we need more
+  // specificity to override page styles, but also
+  // so we don't have to duplicate overrides to both
+  // light & dark theme classes
+  &.pocket-extension,
+  .pocket-extension {
+    *:after,
+    *:before {
+      all: unset;
     }
   }
 `
@@ -97,7 +84,7 @@ export const globalVariables = css`
       --color-itemPreviewBackground: #404040;
     }
 
-    :root {
+    .pocket-extension {
       --color-white100: #FFFFFF;
       --color-grey10: #1A1A1A;
       --color-grey20: #333333;
@@ -120,98 +107,94 @@ export const globalVariables = css`
 `
 
 export const radioStyles = css`
-  :global() {
-    .pocket-extension {
-      input[type='radio'] + label,
-      input[type='checkbox'] + label {
-        display: inline-block;
-        vertical-align: middle;
-        margin: 0 0 0 12px;
+  input[type='radio'] + label,
+  input[type='checkbox'] + label {
+    display: inline-block;
+    vertical-align: middle;
+    margin: 0 0 0 12px;
+  }
+
+  input[type='radio'] {
+    opacity: 0;
+    margin: 0;
+
+    & + label {
+      margin: 4px 0;
+      display: inline-flex;
+      align-items: center;
+      min-height: 24px;
+      position: relative;
+      padding: 0 24px;
+      cursor: pointer;
+      &:before,
+      &:after {
+        box-sizing: border-box;
+        position: absolute;
+        content: '';
+        border-radius: 50%;
+        transition: all 50ms ease;
+        transition-property: transform, border-color;
+      }
+      // radio button border
+      &:before {
+        left: -12px;
+        top: 0;
+        width: 24px;
+        height: 24px;
+        border: 2px solid var(--color-formFieldBorder);
+      }
+      // selected radio button inner circle
+      &:after {
+        top: 5px;
+        left: -7px;
+        width: 14px;
+        height: 14px;
+        transform: scale(0);
+        background: var(--color-actionPrimary);
+      }
+    }
+
+    &:hover:enabled {
+      & + label:before {
+        border-color: var(--color-actionPrimaryHover);
+      }
+    }
+    &:disabled {
+      & + label {
+        opacity: 0.5;
+      }
+      &:hover {
+        & + label:before,
+        & + label {
+          cursor: not-allowed;
+        }
+      }
+    }
+
+    &:checked {
+      & + label:before {
+        border-color: var(--color-actionPrimary);
       }
 
-      input[type='radio'] {
-        opacity: 0;
-        margin: 0;
+      & + label:after {
+        transform: scale(1);
+      }
 
-        & + label {
-          margin: 4px 0;
-          display: inline-flex;
-          align-items: center;
-          min-height: 24px;
-          position: relative;
-          padding: 0 24px;
-          cursor: pointer;
-          &:before,
-          &:after {
-            box-sizing: border-box;
-            position: absolute;
-            content: '';
-            border-radius: 50%;
-            transition: all 50ms ease;
-            transition-property: transform, border-color;
-          }
-          // radio button border
-          &:before {
-            left: -12px;
-            top: 0;
-            width: 24px;
-            height: 24px;
-            border: 2px solid var(--color-formFieldBorder);
-          }
-          // selected radio button inner circle
-          &:after {
-            top: 5px;
-            left: -7px;
-            width: 14px;
-            height: 14px;
-            transform: scale(0);
-            background: var(--color-actionPrimary);
-          }
+      &:hover:enabled,
+      &:active:enabled {
+        & + label:before {
+          border-color: var(--color-actionPrimaryHover);
         }
-
-        &:hover:enabled {
-          & + label:before {
-            border-color: var(--color-actionPrimaryHover);
-          }
+        & + label:after {
+          background: var(--color-actionPrimaryHover);
         }
-        &:disabled {
-          & + label {
-            opacity: 0.5;
-          }
-          &:hover {
-            & + label:before,
-            & + label {
-              cursor: not-allowed;
-            }
-          }
-        }
-
-        &:checked {
-          & + label:before {
-            border-color: var(--color-actionPrimary);
-          }
-
-          & + label:after {
-            transform: scale(1);
-          }
-
-          &:hover:enabled,
-          &:active:enabled {
-            & + label:before {
-              border-color: var(--color-actionPrimaryHover);
-            }
-            & + label:after {
-              background: var(--color-actionPrimaryHover);
-            }
-          }
-        }
-        // same design element regardless of checked or hover
-        &:focus {
-          & + label:before {
-            box-shadow: 0px 0 0 2px var(--color-canvas),
-              0px 0 0 4px var(--color-formFieldFocusLabel);
-          }
-        }
+      }
+    }
+    // same design element regardless of checked or hover
+    &:focus {
+      & + label:before {
+        box-shadow: 0px 0 0 2px var(--color-canvas),
+          0px 0 0 4px var(--color-formFieldFocusLabel);
       }
     }
   }

--- a/src/pages/options/options.js
+++ b/src/pages/options/options.js
@@ -12,12 +12,9 @@ import { FacebookIcon } from 'components/icons/icons'
 import { TwitterIcon } from 'components/icons/icons'
 import { InstagramIcon } from 'components/icons/icons'
 import { PocketLogoIcon } from 'components/icons/icons'
-import { globalVariables, radioStyles, globalReset } from '../injector/globalStyles'
+import { radioStyles } from '../injector/globalStyles'
 
 const container = css`
-  ${globalReset};
-  ${globalVariables};
-  ${radioStyles};
   color: var(--color-textPrimary);
   font-size: 16px;
   width: 100vw;
@@ -173,7 +170,7 @@ const OptionsApp = () => {
   }
 
   return (
-    <div className={cx('pocket-extension', container)}>
+    <div className={cx('pocket-extension', radioStyles, container)}>
       <section className={wrapper}>
         <header className={header}>
           <Logo />


### PR DESCRIPTION
## Goal

Fixes issue https://github.com/Pocket/extension-save-to-pocket/issues/270

## Todos:
- [x] Bump package version
- [x] Remove newly un-needed resets
- [x] Remove global declaration from inputs
- [x] Change scope of color variables from `root` to `.pocket-extension` 
- [x] Update style declarations on options page
- [x] Increase z-index on doorhanger

## Implementation Decisions

Colors are still included on `global`, but scoped specifically to class names so there wouldn't be any style-bleed. 

Removed the `globalVariables` and the `globalReset` variables from `options.js` because they are automatically included in `options.html` with the build css file: `/assets/pocket-save-extension.css`