### PR TITLE
fix(app): add ability to dismiss popover with keyboard [FRONT-1506]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "save-to-pocket",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "private": true,
   "description": "The easiest, fastest way to capture articles, videos, and more.",
   "homepage": "https://github.com/Pocket/extension-save-to-pocket#readme",

--- a/src/common/api/_request/request.js
+++ b/src/common/api/_request/request.js
@@ -37,7 +37,9 @@ async function request(options, skipAuth) {
 function handleErrors(response) {
   if (!response.ok) {
     const e = new Error('Request Error')
-    e.name = response.status === 401 ? 'Auth' : 'Generic'
+    e.name = response.status === 401
+      ? `Auth[${response.status}]`
+      : `Generic[${response.status}]`
     throw e
   }
   return response

--- a/src/pages/background/index.js
+++ b/src/pages/background/index.js
@@ -43,7 +43,7 @@ chrome.runtime.onMessage.addListener(function (message, sender) {
   const { tab } = sender
 
   console.groupCollapsed(`RECEIVE: ${type}`)
-  console.log(message)
+  console.log(payload)
   console.groupEnd(`RECEIVE: ${type}`)
 
   switch (type) {

--- a/src/pages/background/userActions.js
+++ b/src/pages/background/userActions.js
@@ -141,8 +141,15 @@ export async function tagsErrorAction(tab, payload) {
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 export async function authCodeRecieved(tab, payload) {
   const guidResponse = await getGuid()
-  const authResponse = await authorize(guidResponse, payload)
 
+  console.groupCollapsed('PROCESSING AUTH')
+  console.log({
+    ...payload,
+    ...guidResponse
+  })
+  console.groupEnd('PROCESSING AUTH')
+
+  const authResponse = await authorize(guidResponse, payload)
   const { access_token, account, username } = authResponse
   const { premium_status } = account
   setSettings({ access_token, premium_status, username })

--- a/src/pages/injector/app.js
+++ b/src/pages/injector/app.js
@@ -103,14 +103,22 @@ export const App = () => {
     setIsOpen(false)
   }
 
+  const keyPress = (event) => {
+    // keyCode 27 === ESCAPE
+    if (event.keyCode === 27) setIsOpen(false)
+  }
+
   useEffect(() => {
     setIsOpen(true)
 
     chrome.runtime.onMessage.addListener(handleMessages)
     document.addEventListener('click', handleDocumentClick)
+    document.addEventListener('keyup', keyPress)
+
     return () => {
       chrome.runtime.onMessage.removeListener(handleMessages)
       document.removeEventListener('click', handleDocumentClick)
+      document.addEventListener('keyup', keyPress)
     }
   }, [])
 

--- a/src/pages/injector/app.js
+++ b/src/pages/injector/app.js
@@ -103,9 +103,9 @@ export const App = () => {
     setIsOpen(false)
   }
 
-  const keyPress = (event) => {
+  const keyPress = (e) => {
     // keyCode 27 === ESCAPE
-    if (event.keyCode === 27) setIsOpen(false)
+    if (e.keyCode === 27) setIsOpen(false)
   }
 
   useEffect(() => {

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -11,6 +11,16 @@ if (document.readyState === 'loading') {
 async function setLoginLoaded() {
   try {
     const siteCookies = getCookies(document.cookie)
+
+    if (!siteCookies['sess_user_id'] || !siteCookies['sess_exttok']) {
+      console.groupCollapsed('Auth Error')
+      console.log({
+        userId: siteCookies['sess_user_id'],
+        token: siteCookies['sess_exttok']
+      })
+      console.groupEnd('Auth Error')
+    }
+
     const loginMessage = {
       userId: siteCookies['sess_user_id'],
       token: siteCookies['sess_exttok'],
@@ -23,9 +33,9 @@ async function setLoginLoaded() {
         type: AUTH_CODE_RECEIVED,
         payload: loginMessage,
       })
-    }, 1000)
+    }, 1500)
   } catch (err) {
-    console.log(err)
+    console.log('Unexpected login error', err)
   }
 }
 


### PR DESCRIPTION
## Goal

We've heard from users that removing the timed dismissal of the Save popover caused problems in their workflow, so I've added the ability to dismiss the popover using the ESCAPE key

## Todos:
- [x] Bump package version
- [x] Add keydown listener for ESCAPE key

## Implementation Decisions

I added this at the top `app` level as that's where the open/close state of the popover is stored.

![giphy](https://user-images.githubusercontent.com/1273879/144113565-4d4ba317-7407-4d86-9138-0ca5cd7f7582.gif)