### PR TITLE
fix(auth): adding logging to the auth process for support team [FRONT-1488]

### DIFF
--- a/src/common/api/_request/request.js
+++ b/src/common/api/_request/request.js
@@ -37,7 +37,9 @@ async function request(options, skipAuth) {
 function handleErrors(response) {
   if (!response.ok) {
     const e = new Error('Request Error')
-    e.name = response.status === 401 ? 'Auth' : 'Generic'
+    e.name = response.status === 401
+      ? `Auth[${response.status}]`
+      : `Generic[${response.status}]`
     throw e
   }
   return response

--- a/src/pages/background/index.js
+++ b/src/pages/background/index.js
@@ -43,7 +43,7 @@ chrome.runtime.onMessage.addListener(function (message, sender) {
   const { tab } = sender
 
   console.groupCollapsed(`RECEIVE: ${type}`)
-  console.log(message)
+  console.log(payload)
   console.groupEnd(`RECEIVE: ${type}`)
 
   switch (type) {

--- a/src/pages/background/userActions.js
+++ b/src/pages/background/userActions.js
@@ -141,8 +141,15 @@ export async function tagsErrorAction(tab, payload) {
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 export async function authCodeRecieved(tab, payload) {
   const guidResponse = await getGuid()
-  const authResponse = await authorize(guidResponse, payload)
 
+  console.groupCollapsed('PROCESSING AUTH')
+  console.log({
+    ...payload,
+    ...guidResponse
+  })
+  console.groupEnd('PROCESSING AUTH')
+
+  const authResponse = await authorize(guidResponse, payload)
   const { access_token, account, username } = authResponse
   const { premium_status } = account
   setSettings({ access_token, premium_status, username })

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -11,6 +11,16 @@ if (document.readyState === 'loading') {
 async function setLoginLoaded() {
   try {
     const siteCookies = getCookies(document.cookie)
+
+    if (!siteCookies['sess_user_id'] || !siteCookies['sess_exttok']) {
+      console.groupCollapsed('Auth Error')
+      console.log({
+        userId: siteCookies['sess_user_id'],
+        token: siteCookies['sess_exttok']
+      })
+      console.groupEnd('Auth Error')
+    }
+
     const loginMessage = {
       userId: siteCookies['sess_user_id'],
       token: siteCookies['sess_exttok'],
@@ -23,9 +33,9 @@ async function setLoginLoaded() {
         type: AUTH_CODE_RECEIVED,
         payload: loginMessage,
       })
-    }, 1000)
+    }, 1500)
   } catch (err) {
-    console.log(err)
+    console.log('Unexpected login error', err)
   }
 }
 


### PR DESCRIPTION
## Goal

Adding logging to help the Support team troubleshoot auth issues our users are having.

## Todos:
- [x] Add `response.status` to our request errors
- [x] Add logging to display the `userId`, `token`, `guid`, and where the `guid` came from
- [x] Add logging to `login` page for `userId` and `token` as quick first step check

## Implementation Decisions

It's difficult to reproduce the auth issues our users are running into, so I've added logging that our Support team can ask for. 

The first bit of logging is for the `getpocket.com/extension_login_success` page. If this page hangs, you can open the console and verify whether there is a stored cookie for `token` or `userId`. These cookies should be created on the previous page.

The second bit of logging is displays the `userId`, `token`, `guid` and where the `guid` originates. The `guid` can originate from `extension` (stored in `chrome.storage`), `site` (stored in a cookie as `sess_guid`), or `server` (fetched from `v3/guid`). There should be 4 values in this object.

The last bit is adding the `response.status` to our request error handler. This way it's surfaced in the extension service worker console instead of needing to dig for it within the network panel.