### PR TITLE
fix(storage): add error handling to setting or getting storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "save-to-pocket",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "private": true,
   "description": "The easiest, fastest way to capture articles, videos, and more.",
   "homepage": "https://github.com/Pocket/extension-save-to-pocket#readme",

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "Da ist etwas schiefgegangen."
+  },
   "heading_saving" : {
     "message" : "Speichern..."
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -5,6 +5,9 @@
   "heading_idle": {
     "message": ""
   },
+  "heading_error": {
+    "message": "Something went wrong!"
+  },
   "heading_saving": {
     "message": "Saving..."
   },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "¡Parece que algo ha ido mal!"
+  },
   "heading_saving" : {
     "message" : "Guardando…"
   },

--- a/src/_locales/es_419/messages.json
+++ b/src/_locales/es_419/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "¡Se produjo un error!"
+  },
   "heading_saving" : {
     "message" : "Guardando..."
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "Un problème est survenu !"
+  },
   "heading_saving" : {
     "message" : "Sauvegarde..."
   },

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -5,8 +5,8 @@
   "heading_idle" : {
     "message" : ""
   },
-  "heading_saving" : {
-    "message" : "Salvataggio..."
+  "heading_error": {
+    "message" : "Qualcosa non ha funzionato."
   },
   "heading_saved" : {
     "message" : "Salvato in Pocket"

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -8,6 +8,9 @@
   "heading_error": {
     "message" : "Qualcosa non ha funzionato."
   },
+  "heading_saving" : {
+    "message" : "Salvataggio..."
+  },
   "heading_saved" : {
     "message" : "Salvato in Pocket"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "エラーが発生したようです。"
+  },
   "heading_saving" : {
     "message" : "保存中..."
   },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "문제가 발생했습니다!"
+  },
   "heading_saving" : {
     "message" : "저장 중..."
   },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "Er is iets misgegaan!"
+  },
   "heading_saving" : {
     "message" : "Opslaan..."
   },

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "Wystąpił problem."
+  },
   "heading_saving" : {
     "message" : "Zapisywanie..."
   },

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -8,6 +8,9 @@
   "heading_error": {
     "message" : "Ocorreu um erro!"
   },
+  "heading_saving" : {
+    "message" : "Salvando..."
+  },
   "heading_saved" : {
     "message" : "Salvo no Pocket"
   },

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -5,8 +5,8 @@
   "heading_idle" : {
     "message" : ""
   },
-  "heading_saving" : {
-    "message" : "Salvando…"
+  "heading_error": {
+    "message" : "Ocorreu um erro!"
   },
   "heading_saved" : {
     "message" : "Salvo no Pocket"

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -6,13 +6,16 @@
     "message" : ""
   },
   "heading_error": {
-    "message" : "Ocorreu um erro!"
+    "message" : "Algo correu mal!"
+  },
+  "heading_saving" : {
+    "message" : "A guardar..."
   },
   "heading_saved" : {
     "message" : "Guardado no Pocket"
   },
   "heading_save_failed" : {
-    "message" : "Ocorreu um erro!"
+    "message" : "Algo correu mal!"
   },
   "heading_removing" : {
     "message" : "A remover..."

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -5,14 +5,14 @@
   "heading_idle" : {
     "message" : ""
   },
-  "heading_saving" : {
-    "message" : "A guardar…"
+  "heading_error": {
+    "message" : "Ocorreu um erro!"
   },
   "heading_saved" : {
     "message" : "Guardado no Pocket"
   },
   "heading_save_failed" : {
-    "message" : "Algo correu mal!"
+    "message" : "Ocorreu um erro!"
   },
   "heading_removing" : {
     "message" : "A remover..."

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "К сожалению, что-то пошло не так!"
+  },
   "heading_saving" : {
     "message" : "Сохранение..."
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "出错了！"
+  },
   "heading_saving" : {
     "message" : "保存..."
   },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -5,6 +5,9 @@
   "heading_idle" : {
     "message" : ""
   },
+  "heading_error": {
+    "message" : "出了點問題！"
+  },
   "heading_saving" : {
     "message" : "正在儲存..."
   },

--- a/src/common/api/_request/request.js
+++ b/src/common/api/_request/request.js
@@ -18,6 +18,7 @@ async function request(options, skipAuth) {
   })
 
   //?? Is there any way to access this anymore since we no longer use cookie/local storage
+  //?? We never set this parameter anywhere; propose we delete this block
   const serverAuth = await getSetting('base_server_auth')
   if (serverAuth) {
     headers.append('Authorization', 'Basic ' + Base64.encode(serverAuth))

--- a/src/common/api/auth/guid.js
+++ b/src/common/api/auth/guid.js
@@ -1,6 +1,5 @@
 import { request } from '../_request/request'
 import { getSetting } from '../../interface'
-import { arrayHasValues } from '../../utilities'
 
 export async function getGuid() {
   const extensionGuid = await getExtensionGuid()

--- a/src/common/interface.js
+++ b/src/common/interface.js
@@ -81,11 +81,11 @@ export function setSettings(values) {
   })
 }
 
-function handleSettingError(message) {
+function handleSettingError(err) {
   Sentry.withScope((scope) => {
     scope.setFingerprint('Storage Error')
-    Sentry.captureMessage(`Storage Error: ${message}`)
+    Sentry.captureMessage(err)
   })
 
-  console.error(message)
+  console.error(err)
 }

--- a/src/common/interface.js
+++ b/src/common/interface.js
@@ -60,12 +60,11 @@ export function inactiveIcon() {
 export function getSetting(key) {
   return new Promise((resolve, reject) => {
     chrome.storage.local.get([key], (result) => {
-      // if (chrome.runtime.lastError) {
-      // handleSettingError(chrome.runtime.lastError)
-      handleSettingError('setting error')
+      if (chrome.runtime.lastError) {
+        handleSettingError(chrome.runtime.lastError)
         return reject('Trouble reading local Pocket settings')
-      // }
-      // resolve(result[key])
+      }
+      resolve(result[key])
     })
   })
 }
@@ -83,10 +82,10 @@ export function setSettings(values) {
 }
 
 function handleSettingError(message) {
-  // Sentry.withScope((scope) => {
-  //   scope.setFingerprint('Storage Error')
-  //   Sentry.captureMessage(`Storage Error: ${message}`)
-  // })
+  Sentry.withScope((scope) => {
+    scope.setFingerprint('Storage Error')
+    Sentry.captureMessage(`Storage Error: ${message}`)
+  })
 
   console.error(message)
 }

--- a/src/common/interface.js
+++ b/src/common/interface.js
@@ -62,7 +62,7 @@ export function getSetting(key) {
     chrome.storage.local.get([key], (result) => {
       if (chrome.runtime.lastError) {
         handleSettingError(chrome.runtime.lastError)
-        return reject('Trouble reading local Pocket settings')
+        return reject('Error when retrieving local settings')
       }
       resolve(result[key])
     })
@@ -74,7 +74,7 @@ export function setSettings(values) {
     chrome.storage.local.set(values, () => {
       if (chrome.runtime.lastError) {
         handleSettingError(chrome.runtime.lastError)
-        return reject('Trouble saving local Pocket settings')
+        return reject('Error when storing local settings')
       }
       resolve()
     })

--- a/src/common/interface.js
+++ b/src/common/interface.js
@@ -58,24 +58,35 @@ export function inactiveIcon() {
 /* Local Storage
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 export function getSetting(key) {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     chrome.storage.local.get([key], (result) => {
-      handleSettingError('get')
-      resolve(result[key])
+      // if (chrome.runtime.lastError) {
+      // handleSettingError(chrome.runtime.lastError)
+      handleSettingError('setting error')
+        return reject('Trouble reading local Pocket settings')
+      // }
+      // resolve(result[key])
     })
   })
 }
 
 export function setSettings(values) {
-  chrome.storage.local.set(values, () => handleSettingError('set'))
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set(values, () => {
+      if (chrome.runtime.lastError) {
+        handleSettingError(chrome.runtime.lastError)
+        return reject('Trouble saving local Pocket settings')
+      }
+      resolve()
+    })
+  })
 }
 
-function handleSettingError(action) {
-  if (chrome.runtime.lastError) {
-    Sentry.withScope((scope) => {
-      scope.setFingerprint('Storage Error')
-      scope.setTag('setting_action', action)
-      Sentry.captureMessage(chrome.runtime.lastError)
-    })
-  }
+function handleSettingError(message) {
+  // Sentry.withScope((scope) => {
+  //   scope.setFingerprint('Storage Error')
+  //   Sentry.captureMessage(`Storage Error: ${message}`)
+  // })
+
+  console.error(message)
 }

--- a/src/common/interface.js
+++ b/src/common/interface.js
@@ -82,10 +82,10 @@ export function setSettings(values) {
 }
 
 function handleSettingError(err) {
+  console.error(err)
+
   Sentry.withScope((scope) => {
     scope.setFingerprint('Storage Error')
     Sentry.captureMessage(err)
   })
-
-  console.error(err)
 }

--- a/src/common/interface.js
+++ b/src/common/interface.js
@@ -62,7 +62,7 @@ export function getSetting(key) {
     chrome.storage.local.get([key], (result) => {
       if (chrome.runtime.lastError) {
         handleSettingError(chrome.runtime.lastError)
-        return reject('Error when retrieving local settings')
+        return reject('Error when retrieving local settings. Please contact Pocket Support')
       }
       resolve(result[key])
     })
@@ -74,7 +74,7 @@ export function setSettings(values) {
     chrome.storage.local.set(values, () => {
       if (chrome.runtime.lastError) {
         handleSettingError(chrome.runtime.lastError)
-        return reject('Error when storing local settings')
+        return reject('Error when storing local settings. Please contact Pocket Support')
       }
       resolve()
     })

--- a/src/components/button/extensions-button.js
+++ b/src/components/button/extensions-button.js
@@ -11,6 +11,7 @@ const buttonStyles = css`
     line-height: 110%;
     border: none;
     border-radius: 0.25rem;
+    margin: 0;
     padding: 8px 12px;
     transition: all 0.15s ease-out;
     text-decoration: none;

--- a/src/components/error-message/error-message.js
+++ b/src/components/error-message/error-message.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { css } from 'linaria'
+
+const errorMessageStyles = css`
+  color: red;
+  font-size: 16px;
+  padding: 15px 10px;
+`
+
+export const ErrorMessage = ({ message }) => {
+  return (
+    <section className={errorMessageStyles}>
+      {message}
+    </section>
+  )
+}

--- a/src/components/error-message/error-message.js
+++ b/src/components/error-message/error-message.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { css } from 'linaria'
 
 const errorMessageStyles = css`
-  color: red;
+  color: var(--color-headingIcon);
   font-size: 16px;
   padding: 15px 10px;
 `

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -18,7 +18,11 @@ const footerWrapper = css`
     display: inline-block;
     height: 25px;
     width: 25px;
-    margin-right: 8px;
+    margin: 0 8px 0 0;
+    border: none;
+    background-color: transparent;
+    pointer-events: none;
+    vertical-align: middle;
 
     svg {
       height: 25px;

--- a/src/components/heading/heading.js
+++ b/src/components/heading/heading.js
@@ -69,7 +69,7 @@ export const Heading = ({ saveStatus, removeAction, saveAction }) => {
   const loadingStatus = ['saving', 'removing', 'tags_saving']
   const isLoading = loadingStatus.includes(saveStatus)
 
-  const errorStatus = ['save_failed', 'remove_failed', 'tags_failed', 'tags_error']
+  const errorStatus = ['save_failed', 'remove_failed', 'tags_failed', 'tags_error', 'error']
   const hasError = errorStatus.includes(saveStatus)
 
   return (

--- a/src/components/heading/heading.js
+++ b/src/components/heading/heading.js
@@ -32,6 +32,9 @@ const headingStyle = css`
     height: 25px;
     width: 25px;
     margin-top: 0;
+    border: none;
+    background-color: transparent;
+    pointer-events: none;
 
     svg {
       height: 25px;

--- a/src/pages/background/index.js
+++ b/src/pages/background/index.js
@@ -57,34 +57,37 @@ chrome.runtime.onMessage.addListener(function (message, sender) {
   switch (type) {
     case AUTH_CODE_RECEIVED:
       handle.authCodeRecieved(tab, payload)
-      return
+      break
     case USER_LOG_IN:
       handle.logIn(tab)
-      return
+      break
     case LOGGED_OUT_OF_POCKET:
       handle.loggedOutOfPocket(tab)
-      return
+      break
     case REMOVE_ITEM:
       handle.removeItemAction(tab, payload)
-      return
+      break
     case RESAVE_ITEM:
       handle.browserAction(tab)
+      break
     case TAGS_SYNC:
       handle.tagsSyncAction(tab, payload)
-      return
+      break
     case SEND_TAG_ERROR:
       handle.tagsErrorAction(tab, payload)
-      return
+      break
     case COLOR_MODE_CHANGE:
       handle.setColorMode(tab, payload)
-      return
+      break
     case OPEN_POCKET:
       handle.openPocket()
-      return
+      break
     case OPEN_OPTIONS:
       handle.openOptionsPage()
-      return
+      break
     default:
-      return
+      break
   }
+
+  return Promise.resolve(`Message received: ${type}`)
 })

--- a/src/pages/background/index.js
+++ b/src/pages/background/index.js
@@ -57,37 +57,35 @@ chrome.runtime.onMessage.addListener(function (message, sender) {
   switch (type) {
     case AUTH_CODE_RECEIVED:
       handle.authCodeRecieved(tab, payload)
-      break
+      return
     case USER_LOG_IN:
       handle.logIn(tab)
-      break
+      return
     case LOGGED_OUT_OF_POCKET:
       handle.loggedOutOfPocket(tab)
-      break
+      return
     case REMOVE_ITEM:
       handle.removeItemAction(tab, payload)
-      break
+      return
     case RESAVE_ITEM:
       handle.browserAction(tab)
-      break
+      return
     case TAGS_SYNC:
       handle.tagsSyncAction(tab, payload)
-      break
+      return
     case SEND_TAG_ERROR:
       handle.tagsErrorAction(tab, payload)
-      break
+      return
     case COLOR_MODE_CHANGE:
       handle.setColorMode(tab, payload)
-      break
+      return
     case OPEN_POCKET:
       handle.openPocket()
-      break
+      return
     case OPEN_OPTIONS:
       handle.openOptionsPage()
-      break
+      return
     default:
-      break
+      return Promise.resolve(`Message received: ${type}`)
   }
-
-  return Promise.resolve(`Message received: ${type}`)
 })

--- a/src/pages/background/userActions.js
+++ b/src/pages/background/userActions.js
@@ -66,16 +66,16 @@ export function contextClick(info, tab) {
 /* Saving
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 async function save({ linkUrl, pageUrl, title, tabId }) {
-  // Are we authed?
-  const access_token = await getSetting('access_token')
-  if (!access_token) return logIn({ linkUrl, pageUrl, title, tabId })
-
   // send message that we are requesting a save
   chrome.tabs.sendMessage(tabId, { action: SAVE_TO_POCKET_REQUEST })
 
-  const url = linkUrl || pageUrl
-
   try {
+    // Are we authed?
+    const access_token = await getSetting('access_token')
+    if (!access_token) return logIn({ linkUrl, pageUrl, title, tabId })
+
+    const url = linkUrl || pageUrl
+
     const { response: payload } = await saveToPocket({ url, title, tabId })
     // send a message with the response
     const message = payload
@@ -92,7 +92,8 @@ async function save({ linkUrl, pageUrl, title, tabId }) {
     }
 
     // Otherwise let's just show the error message
-    const errorMessage = { action: SAVE_TO_POCKET_FAILURE }
+    const payload = { message: error }
+    const errorMessage = { action: SAVE_TO_POCKET_FAILURE, payload }
     chrome.tabs.sendMessage(tabId, errorMessage)
   }
 }

--- a/src/pages/injector/app.js
+++ b/src/pages/injector/app.js
@@ -5,6 +5,7 @@ import { HeadingConnector } from 'connectors/heading/heading'
 import { ItemPreviewConnector } from 'connectors/item-preview/item-preview'
 import { TaggingConnector } from 'connectors/tagging/tagging'
 import { FooterConnector } from 'connectors/footer/footer'
+import { ErrorMessage } from 'components/error-message/error-message'
 import { getSetting } from 'common/interface'
 import { getOSModeClass } from 'common/helpers'
 import { globalVariables, globalReset } from './globalStyles'
@@ -29,7 +30,8 @@ export const App = () => {
   const appTarget = useRef(null)
   const [saveStatus, setSaveStatus] = useState('saving')
   const [isOpen, setIsOpen] = useState(false)
-  const [theme, setTheme] = useState('pocket-theme-system')
+  const [theme, setTheme] = useState('pocket-theme-light')
+  const [errorMessage, setErrorMessage] = useState('')
 
   /* Handle incoming messages
   –––––––––––––––––––––––––––––––––––––––––––––––––– */
@@ -53,6 +55,8 @@ export const App = () => {
       }
 
       case SAVE_TO_POCKET_FAILURE: {
+        const { message } = payload
+        setErrorMessage(message)
         return setSaveStatus('save_failed')
       }
 
@@ -125,14 +129,16 @@ export const App = () => {
   const closePanel = () => setIsOpen(false)
 
   const isRemoved = saveStatus === 'removed'
+  const hasError = saveStatus === 'save_failed'
 
   return (
     <div ref={appTarget} className={cx('pocket-extension', globalReset, globalVariables, theme)}>
       <Doorhanger isOpen={isOpen}>
         <HeadingConnector saveStatus={saveStatus} />
-        {!isRemoved ? <ItemPreviewConnector /> : null}
-        {!isRemoved ? <TaggingConnector closePanel={closePanel} /> : null}
-        <FooterConnector />
+        {!isRemoved && !hasError ? <ItemPreviewConnector /> : null}
+        {!isRemoved && !hasError ? <TaggingConnector closePanel={closePanel} /> : null}
+        {hasError ? <ErrorMessage message={errorMessage} /> : null}
+        {!hasError ? <FooterConnector /> : null}
       </Doorhanger>
     </div>
   )

--- a/src/pages/injector/content.js
+++ b/src/pages/injector/content.js
@@ -11,18 +11,6 @@ const initialize = function () {
     const { action } = request
     if (action === SAVE_TO_POCKET_REQUEST) injectDomElements()
   })
-
-  // Make sure the toolbar icon is in sync with users light/dark preference
-  const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)')
-  const handleDarkModeChange = (mql) => {
-    const darkMode = mql.matches
-    chrome.runtime.sendMessage({
-      type: COLOR_MODE_CHANGE,
-      payload: { darkMode },
-    })
-  }
-  handleDarkModeChange(mediaQueryList)
-  mediaQueryList.addEventListener('change', handleDarkModeChange)
 }
 
 /* Inject content into the DOM

--- a/src/pages/injector/content.js
+++ b/src/pages/injector/content.js
@@ -2,7 +2,6 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { App } from './app'
 import { SAVE_TO_POCKET_REQUEST } from 'actions'
-import { COLOR_MODE_CHANGE } from 'actions'
 
 /* Initial Setup
 –––––––––––––––––––––––––––––––––––––––––––––––––– */


### PR DESCRIPTION
## Goal

Addressing errors captured by Sentry.

The storage errors seem to be the biggest culprit with the authentication issues experienced by some users. If Chrome can't `get` or `set` items to the local storage, there is no way to save a user's auth status. 

to be merged into https://github.com/Pocket/extension-save-to-pocket/pull/276

<img width="406" alt="image" src="https://user-images.githubusercontent.com/1273879/151876643-6843d5d8-4723-4af2-a579-138fd47e6d19.png">

## Todos:
- [x] Bump package version
- [x] Add error handling to getting and setting `chrome.storage`
- [x] Update message listener in background to return a promise
- [x] Remove un-used check for system theme
- [x] Adding ability to display error messaging to user
- [x] Adding generic error message to localization files

## Implementation Decisions

### IO error: ... FILE_ERROR_NO_SPACE (ChromeMethodBFE: 3::WritableFileAppend::8)
This is a Chrome level error and is related to a user's available disc space when trying to write to `chrome.storage`. There isn't any _real_ documentation on this error provided by Google. In my research I came across another open-source extension where users experienced this issue and it was solved by clearing hard-drive space and rebooting the browser. Not ideal. I've added error handling to our helper function that sets the storage, as well as error logging into Sentry

-----------------------------------

### IO error: .../LOCK: File currently in use. (ChromeMethodBFE: 15::LockFile::2)
This another Chrome level error is caused by Chrome leaving old or "zombie" processes running. Here's a thread that discusses these processes in regards to a similar (but seemingly related) issue: https://bugs.chromium.org/p/chromium/issues/detail?id=490915

Similar to the no space error, there is no documentation provided by Google for this issue. However research surfaced two other extensions with this issue that were fixed by restarting the browser, or restarting the computer. I've added error logging into Sentry when this action fails.

-----------------------------------

### The message port closed before a response was received.
When you add a listener on browser message events you always need to return a promise. Documentation:
- https://developer.chrome.com/docs/extensions/reference/runtime/#event-onMessage
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
- https://github.com/mozilla/webextension-polyfill/issues/130


