### PR TITLE
fix(icon): update the pocket icon to use brand color

### DIFF
--- a/src/components/button/extensions-button.js
+++ b/src/components/button/extensions-button.js
@@ -11,6 +11,7 @@ const buttonStyles = css`
     line-height: 110%;
     border: none;
     border-radius: 0.25rem;
+    margin: 0;
     padding: 8px 12px;
     transition: all 0.15s ease-out;
     text-decoration: none;

--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -18,7 +18,11 @@ const footerWrapper = css`
     display: inline-block;
     height: 25px;
     width: 25px;
-    margin-right: 8px;
+    margin: 0 8px 0 0;
+    border: none;
+    background-color: transparent;
+    pointer-events: none;
+    vertical-align: middle;
 
     svg {
       height: 25px;

--- a/src/components/heading/heading.js
+++ b/src/components/heading/heading.js
@@ -32,6 +32,9 @@ const headingStyle = css`
     height: 25px;
     width: 25px;
     margin-top: 0;
+    border: none;
+    background-color: transparent;
+    pointer-events: none;
 
     svg {
       height: 25px;


### PR DESCRIPTION
## Goal

During the QA process it was discovered that the Header, Footer, and Button icon styles could use some tweaks to prevent style bleed

## Todos:
- [x] Update Header
- [x] Update Footer
- [x] Update Button Icon

## Implementation Decisions

The sites causing trouble were How-To Geek, and Fox Business Network